### PR TITLE
Make perltidy args user configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,3 +49,5 @@ yum install ctags
 Install `Perl::Tidy` and make sure it's available on your `PATH` or specify it's location in the `perl.perltidy` setting. If the value for `perl.perltidy` is left empty, no formatting will be applied.
 
 If you are using docker you can specify in the setting `perl.perltidyContainer` the name of a container in which you have installed `Perl::Tidy`.
+
+The arguments to perltidy are specified with the `perl.perltidyArgs` setting. This is an array in which each element is a string to be passed to perltidy as a command-line argument (including the leading dash). The default is not to pass any arguments.

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
         "url": "https://github.com/henriiik/vscode-perl/issues"
     },
     "homepage": "https://github.com/henriiik/vscode-perl",
-    "categories": ["Languages"],
+    "categories": ["Programming Languages"],
     "publisher": "henriiik",
     "engines": {
         "vscode": "^1.20.1"
@@ -48,6 +48,11 @@
                     "default": "perltidy",
                     "description":
                         "The name or path to the perltidy executable that will be used when formatting code."
+                },
+                "perl.perltidyArgs": {
+                    "type": "array",
+                    "default": [],
+                    "description": "Arguments to perltidy as an array of strings, each element an argument including the leading dash."
                 },
                 "perl.perltidyContainer": {
                     "type": "string",

--- a/src/format.ts
+++ b/src/format.ts
@@ -24,8 +24,7 @@ export class PerlFormattingProvider implements vscode.DocumentRangeFormattingEdi
             let config = vscode.workspace.getConfiguration("perl");
 
             let executable = config.get("perltidy", "perltidy");
-            let args = ["-q", "-et=4", "-t", "-ce", "-l=0", "-bar", "-naws", "-blbs=2", "-mbl=2"]; // , "-otr"
-
+            let args = config.get("perltidyArgs", []);
             let container = config.get("perltidyContainer", "");
             if (container !== "") {
                 args = ["exec", "-i", container, executable].concat(args);


### PR DESCRIPTION
I moved the perltidy args into config, and made the defaults into perltidy's defaults (i.e. no arguments). I don't know how this interacts with .perltidyrc as mentioned in issue #14, but it does let the user put in their own perltidy configuration switches in the vscode user config, which I think would solve the issue (it certainly does for me).