### PR TITLE
Pre-filter results for symbol lookup

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "vscode-perl",
     "displayName": "Perl",
     "description": "Perl code intelligence via ctags.",
-    "version": "1.16.0",
+    "version": "1.17.0",
     "author": "Henrik Sjööh <hello@enhenrik.nu> (http://www.enhenrik.nu)",
     "license": "MIT",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -70,6 +70,18 @@
                     "type": "string",
                     "default": "",
                     "description": "The name of a docker container that will be used to run perltidy. Leave blank if you dont want to use docker."
+                },
+                "perl.maxSymbolResults": {
+                    "type": "number",
+                    "default": 500,
+                    "description": "Total number of symbols to return to vscode from the symbol provider. Higher numbers may decrease performance."
+                },
+                "perl.extraProjectCtagsArgs": {
+                    "type": "array",
+                    "default": [
+                        "--extra=+q"
+                    ],
+                    "description": "Additional ctags parameters to include when generating tags for the project folder."
                 }
             }
         }

--- a/src/ctags.ts
+++ b/src/ctags.ts
@@ -49,6 +49,10 @@ export class Ctags {
         return this.getConfiguration().get("ctagsPath", "ctags");
     }
 
+    getExtraProjectCtagsArgs(): string[] {
+        return this.getConfiguration().get("extraProjectCtagsArgs", []);
+    }
+
     async checkVersion(): Promise<Option<Error>> {
         if (this.versionOk) {
             return undefined;
@@ -122,7 +126,7 @@ export class Ctags {
 
     async generateProjectFolderTagsFile(folder: vscode.WorkspaceFolder) {
         let filename = this.getTagsFileName(folder.uri);
-        let args = DEFAULT_ARGS.concat(["-R", "--perl-kinds=psc", "-f", filename]);
+        let args = DEFAULT_ARGS.concat(this.getExtraProjectCtagsArgs()).concat(["-R", "--perl-kinds=psc", "-f", filename]);
 
         let res = await this.run(args, folder.uri.fsPath);
         if (

--- a/src/sorting.ts
+++ b/src/sorting.ts
@@ -1,0 +1,92 @@
+import * as vscode from "vscode";
+import { compareAnything } from "./vs/base/common/comparers";
+import { IMatch } from "./vs/base/common/filters";
+
+let IDS = 0;
+export class SymbolEntry {
+	private id: string;
+    private labelHighlights: IMatch[] = [];
+    private bearing: vscode.SymbolInformation;
+
+	constructor(
+		symbol: vscode.SymbolInformation
+	) {
+		this.id = (IDS++).toString();
+        this.bearing = symbol;
+    }
+
+    getSymbol(): vscode.SymbolInformation {
+        return this.bearing;
+    }
+
+	getLabel(): string {
+		return this.bearing.name;
+	}
+	getResource(): vscode.Uri {
+		return this.bearing.location.uri;
+    }
+
+	/**
+	 * A unique identifier for the entry
+	 */
+	getId(): string {
+		return this.id;
+	}
+
+	/**
+	 * Allows to set highlight ranges that should show up for the entry label and optionally description if set.
+	 */
+	setHighlights(labelHighlights: IMatch[]): void {
+		this.labelHighlights = labelHighlights;
+	}
+
+	/**
+	 * Allows to return highlight ranges that should show up for the entry label and description.
+	 */
+    getHighlights(): IMatch[] {
+		return this.labelHighlights;
+	}
+
+	static compare(elementA: SymbolEntry, elementB: SymbolEntry, searchValue: string): number {
+		const elementAName = elementA.getLabel().toLowerCase();
+		const elementBName = elementB.getLabel().toLowerCase();
+		if (elementAName === elementBName) {
+			return 0;
+		}
+		return compareEntries(elementA, elementB, searchValue);
+	}
+}
+
+/**
+ * A good default sort implementation for quick open entries respecting highlight information
+ * as well as associated resources.
+ */
+function compareEntries(elementA: SymbolEntry, elementB: SymbolEntry, lookFor: string): number {
+
+	// Give matches with label highlights higher priority over
+	// those with only description highlights
+	const labelHighlightsA = elementA.getHighlights() || [];
+	const labelHighlightsB = elementB.getHighlights() || [];
+	if (labelHighlightsA.length && !labelHighlightsB.length) {
+		return -1;
+	}
+
+	if (!labelHighlightsA.length && labelHighlightsB.length) {
+		return 1;
+	}
+
+	// Fallback to the full path if labels are identical and we have associated resources
+	let nameA = elementA.getLabel();
+	let nameB = elementB.getLabel();
+	if (nameA === nameB) {
+		const resourceA = elementA.getResource();
+		const resourceB = elementB.getResource();
+
+		if (resourceA && resourceB) {
+			nameA = resourceA.fsPath;
+			nameB = resourceB.fsPath;
+		}
+	}
+
+	return compareAnything(nameA, nameB, lookFor);
+}

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -50,8 +50,8 @@ export class PerlSymbolProvider
         query: string,
         token: vscode.CancellationToken
     ): Promise<vscode.SymbolInformation[]> {
-		if (query.length <= 2) {
-			return [];
+        if (query.length <= 2) {
+            return [];
         }
 
         let symbols: vscode.SymbolInformation[] = [];
@@ -79,7 +79,7 @@ export class PerlSymbolProvider
                         kind = vscode.SymbolKind.Variable;
                     }
 
-					if (kind == vscode.SymbolKind.Function && name.match(queryRegEx)) {
+                    if (kind == vscode.SymbolKind.Function && name.match(queryRegEx)) {
                         let lineNo = parseInt(match[2].replace(/[^\d]/g, "")) - 1;
 
                         let range = new vscode.Range(lineNo, 0, lineNo, 0);

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -50,6 +50,10 @@ export class PerlSymbolProvider
         query: string,
         token: vscode.CancellationToken
     ): Promise<vscode.SymbolInformation[]> {
+		if (query.length <= 2) {
+			return [];
+        }
+
         let symbols: vscode.SymbolInformation[] = [];
         let results = await this.tags.readProjectTags();
 
@@ -62,6 +66,7 @@ export class PerlSymbolProvider
             let lines = tags.data.split("\n");
             let last = lines.length - 1;
             let match: string[];
+            let queryRegEx = new RegExp(query, "gi");
 
             for (let i = 0; i <= last; i++) {
                 match = lines[i].split("\t");
@@ -73,17 +78,20 @@ export class PerlSymbolProvider
                         console.error("Unknown symbol kind:", match[3]);
                         kind = vscode.SymbolKind.Variable;
                     }
-                    let lineNo = parseInt(match[2].replace(/[^\d]/g, "")) - 1;
 
-                    let range = new vscode.Range(lineNo, 0, lineNo, 0);
+					if (kind == vscode.SymbolKind.Function && name.match(queryRegEx)) {
+                        let lineNo = parseInt(match[2].replace(/[^\d]/g, "")) - 1;
 
-                    let file = match[1].replace(/^\.\\/, "");
-                    let filePath = path.join(vscode.workspace.rootPath || "", file);
-                    let uri = vscode.Uri.file(filePath);
+                        let range = new vscode.Range(lineNo, 0, lineNo, 0);
 
-                    let info = new vscode.SymbolInformation(name, kind, range, uri);
+                        let file = match[1].replace(/^\.\\/, "");
+                        let filePath = path.join(vscode.workspace.rootPath || "", file);
+                        let uri = vscode.Uri.file(filePath);
 
-                    symbols.push(info);
+                        let info = new vscode.SymbolInformation(name, kind, range, uri);
+
+                        symbols.push(info);
+                    }
                 }
             }
         }

--- a/src/symbols.ts
+++ b/src/symbols.ts
@@ -50,7 +50,7 @@ export class PerlSymbolProvider
         query: string,
         token: vscode.CancellationToken
     ): Promise<vscode.SymbolInformation[]> {
-        if (query.length <= 2) {
+        if (query.length < 2) {
             return [];
         }
 
@@ -79,7 +79,7 @@ export class PerlSymbolProvider
                         kind = vscode.SymbolKind.Variable;
                     }
 
-                    if (kind == vscode.SymbolKind.Function && name.match(queryRegEx)) {
+                    if (name.match(queryRegEx)) {
                         let lineNo = parseInt(match[2].replace(/[^\d]/g, "")) - 1;
 
                         let range = new vscode.Range(lineNo, 0, lineNo, 0);

--- a/src/vs/base/common/charCode.ts
+++ b/src/vs/base/common/charCode.ts
@@ -1,0 +1,425 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+// Names from https://blog.codinghorror.com/ascii-pronunciation-rules-for-programmers/
+
+/**
+ * An inlined enum containing useful character codes (to be used with String.charCodeAt).
+ * Please leave the const keyword such that it gets inlined when compiled to JavaScript!
+ */
+export const enum CharCode {
+	Null = 0,
+	/**
+	 * The `\b` character.
+	 */
+	Backspace = 8,
+	/**
+	 * The `\t` character.
+	 */
+	Tab = 9,
+	/**
+	 * The `\n` character.
+	 */
+	LineFeed = 10,
+	/**
+	 * The `\r` character.
+	 */
+	CarriageReturn = 13,
+	Space = 32,
+	/**
+	 * The `!` character.
+	 */
+	ExclamationMark = 33,
+	/**
+	 * The `"` character.
+	 */
+	DoubleQuote = 34,
+	/**
+	 * The `#` character.
+	 */
+	Hash = 35,
+	/**
+	 * The `$` character.
+	 */
+	DollarSign = 36,
+	/**
+	 * The `%` character.
+	 */
+	PercentSign = 37,
+	/**
+	 * The `&` character.
+	 */
+	Ampersand = 38,
+	/**
+	 * The `'` character.
+	 */
+	SingleQuote = 39,
+	/**
+	 * The `(` character.
+	 */
+	OpenParen = 40,
+	/**
+	 * The `)` character.
+	 */
+	CloseParen = 41,
+	/**
+	 * The `*` character.
+	 */
+	Asterisk = 42,
+	/**
+	 * The `+` character.
+	 */
+	Plus = 43,
+	/**
+	 * The `,` character.
+	 */
+	Comma = 44,
+	/**
+	 * The `-` character.
+	 */
+	Dash = 45,
+	/**
+	 * The `.` character.
+	 */
+	Period = 46,
+	/**
+	 * The `/` character.
+	 */
+	Slash = 47,
+
+	Digit0 = 48,
+	Digit1 = 49,
+	Digit2 = 50,
+	Digit3 = 51,
+	Digit4 = 52,
+	Digit5 = 53,
+	Digit6 = 54,
+	Digit7 = 55,
+	Digit8 = 56,
+	Digit9 = 57,
+
+	/**
+	 * The `:` character.
+	 */
+	Colon = 58,
+	/**
+	 * The `;` character.
+	 */
+	Semicolon = 59,
+	/**
+	 * The `<` character.
+	 */
+	LessThan = 60,
+	/**
+	 * The `=` character.
+	 */
+	Equals = 61,
+	/**
+	 * The `>` character.
+	 */
+	GreaterThan = 62,
+	/**
+	 * The `?` character.
+	 */
+	QuestionMark = 63,
+	/**
+	 * The `@` character.
+	 */
+	AtSign = 64,
+
+	A = 65,
+	B = 66,
+	C = 67,
+	D = 68,
+	E = 69,
+	F = 70,
+	G = 71,
+	H = 72,
+	I = 73,
+	J = 74,
+	K = 75,
+	L = 76,
+	M = 77,
+	N = 78,
+	O = 79,
+	P = 80,
+	Q = 81,
+	R = 82,
+	S = 83,
+	T = 84,
+	U = 85,
+	V = 86,
+	W = 87,
+	X = 88,
+	Y = 89,
+	Z = 90,
+
+	/**
+	 * The `[` character.
+	 */
+	OpenSquareBracket = 91,
+	/**
+	 * The `\` character.
+	 */
+	Backslash = 92,
+	/**
+	 * The `]` character.
+	 */
+	CloseSquareBracket = 93,
+	/**
+	 * The `^` character.
+	 */
+	Caret = 94,
+	/**
+	 * The `_` character.
+	 */
+	Underline = 95,
+	/**
+	 * The ``(`)`` character.
+	 */
+	BackTick = 96,
+
+	a = 97,
+	b = 98,
+	c = 99,
+	d = 100,
+	e = 101,
+	f = 102,
+	g = 103,
+	h = 104,
+	i = 105,
+	j = 106,
+	k = 107,
+	l = 108,
+	m = 109,
+	n = 110,
+	o = 111,
+	p = 112,
+	q = 113,
+	r = 114,
+	s = 115,
+	t = 116,
+	u = 117,
+	v = 118,
+	w = 119,
+	x = 120,
+	y = 121,
+	z = 122,
+
+	/**
+	 * The `{` character.
+	 */
+	OpenCurlyBrace = 123,
+	/**
+	 * The `|` character.
+	 */
+	Pipe = 124,
+	/**
+	 * The `}` character.
+	 */
+	CloseCurlyBrace = 125,
+	/**
+	 * The `~` character.
+	 */
+	Tilde = 126,
+
+	U_Combining_Grave_Accent = 0x0300,								//	U+0300	Combining Grave Accent
+	U_Combining_Acute_Accent = 0x0301,								//	U+0301	Combining Acute Accent
+	U_Combining_Circumflex_Accent = 0x0302,							//	U+0302	Combining Circumflex Accent
+	U_Combining_Tilde = 0x0303,										//	U+0303	Combining Tilde
+	U_Combining_Macron = 0x0304,									//	U+0304	Combining Macron
+	U_Combining_Overline = 0x0305,									//	U+0305	Combining Overline
+	U_Combining_Breve = 0x0306,										//	U+0306	Combining Breve
+	U_Combining_Dot_Above = 0x0307,									//	U+0307	Combining Dot Above
+	U_Combining_Diaeresis = 0x0308,									//	U+0308	Combining Diaeresis
+	U_Combining_Hook_Above = 0x0309,								//	U+0309	Combining Hook Above
+	U_Combining_Ring_Above = 0x030A,								//	U+030A	Combining Ring Above
+	U_Combining_Double_Acute_Accent = 0x030B,						//	U+030B	Combining Double Acute Accent
+	U_Combining_Caron = 0x030C,										//	U+030C	Combining Caron
+	U_Combining_Vertical_Line_Above = 0x030D,						//	U+030D	Combining Vertical Line Above
+	U_Combining_Double_Vertical_Line_Above = 0x030E,				//	U+030E	Combining Double Vertical Line Above
+	U_Combining_Double_Grave_Accent = 0x030F,						//	U+030F	Combining Double Grave Accent
+	U_Combining_Candrabindu = 0x0310,								//	U+0310	Combining Candrabindu
+	U_Combining_Inverted_Breve = 0x0311,							//	U+0311	Combining Inverted Breve
+	U_Combining_Turned_Comma_Above = 0x0312,						//	U+0312	Combining Turned Comma Above
+	U_Combining_Comma_Above = 0x0313,								//	U+0313	Combining Comma Above
+	U_Combining_Reversed_Comma_Above = 0x0314,						//	U+0314	Combining Reversed Comma Above
+	U_Combining_Comma_Above_Right = 0x0315,							//	U+0315	Combining Comma Above Right
+	U_Combining_Grave_Accent_Below = 0x0316,						//	U+0316	Combining Grave Accent Below
+	U_Combining_Acute_Accent_Below = 0x0317,						//	U+0317	Combining Acute Accent Below
+	U_Combining_Left_Tack_Below = 0x0318,							//	U+0318	Combining Left Tack Below
+	U_Combining_Right_Tack_Below = 0x0319,							//	U+0319	Combining Right Tack Below
+	U_Combining_Left_Angle_Above = 0x031A,							//	U+031A	Combining Left Angle Above
+	U_Combining_Horn = 0x031B,										//	U+031B	Combining Horn
+	U_Combining_Left_Half_Ring_Below = 0x031C,						//	U+031C	Combining Left Half Ring Below
+	U_Combining_Up_Tack_Below = 0x031D,								//	U+031D	Combining Up Tack Below
+	U_Combining_Down_Tack_Below = 0x031E,							//	U+031E	Combining Down Tack Below
+	U_Combining_Plus_Sign_Below = 0x031F,							//	U+031F	Combining Plus Sign Below
+	U_Combining_Minus_Sign_Below = 0x0320,							//	U+0320	Combining Minus Sign Below
+	U_Combining_Palatalized_Hook_Below = 0x0321,					//	U+0321	Combining Palatalized Hook Below
+	U_Combining_Retroflex_Hook_Below = 0x0322,						//	U+0322	Combining Retroflex Hook Below
+	U_Combining_Dot_Below = 0x0323,									//	U+0323	Combining Dot Below
+	U_Combining_Diaeresis_Below = 0x0324,							//	U+0324	Combining Diaeresis Below
+	U_Combining_Ring_Below = 0x0325,								//	U+0325	Combining Ring Below
+	U_Combining_Comma_Below = 0x0326,								//	U+0326	Combining Comma Below
+	U_Combining_Cedilla = 0x0327,									//	U+0327	Combining Cedilla
+	U_Combining_Ogonek = 0x0328,									//	U+0328	Combining Ogonek
+	U_Combining_Vertical_Line_Below = 0x0329,						//	U+0329	Combining Vertical Line Below
+	U_Combining_Bridge_Below = 0x032A,								//	U+032A	Combining Bridge Below
+	U_Combining_Inverted_Double_Arch_Below = 0x032B,				//	U+032B	Combining Inverted Double Arch Below
+	U_Combining_Caron_Below = 0x032C,								//	U+032C	Combining Caron Below
+	U_Combining_Circumflex_Accent_Below = 0x032D,					//	U+032D	Combining Circumflex Accent Below
+	U_Combining_Breve_Below = 0x032E,								//	U+032E	Combining Breve Below
+	U_Combining_Inverted_Breve_Below = 0x032F,						//	U+032F	Combining Inverted Breve Below
+	U_Combining_Tilde_Below = 0x0330,								//	U+0330	Combining Tilde Below
+	U_Combining_Macron_Below = 0x0331,								//	U+0331	Combining Macron Below
+	U_Combining_Low_Line = 0x0332,									//	U+0332	Combining Low Line
+	U_Combining_Double_Low_Line = 0x0333,							//	U+0333	Combining Double Low Line
+	U_Combining_Tilde_Overlay = 0x0334,								//	U+0334	Combining Tilde Overlay
+	U_Combining_Short_Stroke_Overlay = 0x0335,						//	U+0335	Combining Short Stroke Overlay
+	U_Combining_Long_Stroke_Overlay = 0x0336,						//	U+0336	Combining Long Stroke Overlay
+	U_Combining_Short_Solidus_Overlay = 0x0337,						//	U+0337	Combining Short Solidus Overlay
+	U_Combining_Long_Solidus_Overlay = 0x0338,						//	U+0338	Combining Long Solidus Overlay
+	U_Combining_Right_Half_Ring_Below = 0x0339,						//	U+0339	Combining Right Half Ring Below
+	U_Combining_Inverted_Bridge_Below = 0x033A,						//	U+033A	Combining Inverted Bridge Below
+	U_Combining_Square_Below = 0x033B,								//	U+033B	Combining Square Below
+	U_Combining_Seagull_Below = 0x033C,								//	U+033C	Combining Seagull Below
+	U_Combining_X_Above = 0x033D,									//	U+033D	Combining X Above
+	U_Combining_Vertical_Tilde = 0x033E,							//	U+033E	Combining Vertical Tilde
+	U_Combining_Double_Overline = 0x033F,							//	U+033F	Combining Double Overline
+	U_Combining_Grave_Tone_Mark = 0x0340,							//	U+0340	Combining Grave Tone Mark
+	U_Combining_Acute_Tone_Mark = 0x0341,							//	U+0341	Combining Acute Tone Mark
+	U_Combining_Greek_Perispomeni = 0x0342,							//	U+0342	Combining Greek Perispomeni
+	U_Combining_Greek_Koronis = 0x0343,								//	U+0343	Combining Greek Koronis
+	U_Combining_Greek_Dialytika_Tonos = 0x0344,						//	U+0344	Combining Greek Dialytika Tonos
+	U_Combining_Greek_Ypogegrammeni = 0x0345,						//	U+0345	Combining Greek Ypogegrammeni
+	U_Combining_Bridge_Above = 0x0346,								//	U+0346	Combining Bridge Above
+	U_Combining_Equals_Sign_Below = 0x0347,							//	U+0347	Combining Equals Sign Below
+	U_Combining_Double_Vertical_Line_Below = 0x0348,				//	U+0348	Combining Double Vertical Line Below
+	U_Combining_Left_Angle_Below = 0x0349,							//	U+0349	Combining Left Angle Below
+	U_Combining_Not_Tilde_Above = 0x034A,							//	U+034A	Combining Not Tilde Above
+	U_Combining_Homothetic_Above = 0x034B,							//	U+034B	Combining Homothetic Above
+	U_Combining_Almost_Equal_To_Above = 0x034C,						//	U+034C	Combining Almost Equal To Above
+	U_Combining_Left_Right_Arrow_Below = 0x034D,					//	U+034D	Combining Left Right Arrow Below
+	U_Combining_Upwards_Arrow_Below = 0x034E,						//	U+034E	Combining Upwards Arrow Below
+	U_Combining_Grapheme_Joiner = 0x034F,							//	U+034F	Combining Grapheme Joiner
+	U_Combining_Right_Arrowhead_Above = 0x0350,						//	U+0350	Combining Right Arrowhead Above
+	U_Combining_Left_Half_Ring_Above = 0x0351,						//	U+0351	Combining Left Half Ring Above
+	U_Combining_Fermata = 0x0352,									//	U+0352	Combining Fermata
+	U_Combining_X_Below = 0x0353,									//	U+0353	Combining X Below
+	U_Combining_Left_Arrowhead_Below = 0x0354,						//	U+0354	Combining Left Arrowhead Below
+	U_Combining_Right_Arrowhead_Below = 0x0355,						//	U+0355	Combining Right Arrowhead Below
+	U_Combining_Right_Arrowhead_And_Up_Arrowhead_Below = 0x0356,	//	U+0356	Combining Right Arrowhead And Up Arrowhead Below
+	U_Combining_Right_Half_Ring_Above = 0x0357,						//	U+0357	Combining Right Half Ring Above
+	U_Combining_Dot_Above_Right = 0x0358,							//	U+0358	Combining Dot Above Right
+	U_Combining_Asterisk_Below = 0x0359,							//	U+0359	Combining Asterisk Below
+	U_Combining_Double_Ring_Below = 0x035A,							//	U+035A	Combining Double Ring Below
+	U_Combining_Zigzag_Above = 0x035B,								//	U+035B	Combining Zigzag Above
+	U_Combining_Double_Breve_Below = 0x035C,						//	U+035C	Combining Double Breve Below
+	U_Combining_Double_Breve = 0x035D,								//	U+035D	Combining Double Breve
+	U_Combining_Double_Macron = 0x035E,								//	U+035E	Combining Double Macron
+	U_Combining_Double_Macron_Below = 0x035F,						//	U+035F	Combining Double Macron Below
+	U_Combining_Double_Tilde = 0x0360,								//	U+0360	Combining Double Tilde
+	U_Combining_Double_Inverted_Breve = 0x0361,						//	U+0361	Combining Double Inverted Breve
+	U_Combining_Double_Rightwards_Arrow_Below = 0x0362,				//	U+0362	Combining Double Rightwards Arrow Below
+	U_Combining_Latin_Small_Letter_A = 0x0363, 						//	U+0363	Combining Latin Small Letter A
+	U_Combining_Latin_Small_Letter_E = 0x0364, 						//	U+0364	Combining Latin Small Letter E
+	U_Combining_Latin_Small_Letter_I = 0x0365, 						//	U+0365	Combining Latin Small Letter I
+	U_Combining_Latin_Small_Letter_O = 0x0366, 						//	U+0366	Combining Latin Small Letter O
+	U_Combining_Latin_Small_Letter_U = 0x0367, 						//	U+0367	Combining Latin Small Letter U
+	U_Combining_Latin_Small_Letter_C = 0x0368, 						//	U+0368	Combining Latin Small Letter C
+	U_Combining_Latin_Small_Letter_D = 0x0369, 						//	U+0369	Combining Latin Small Letter D
+	U_Combining_Latin_Small_Letter_H = 0x036A, 						//	U+036A	Combining Latin Small Letter H
+	U_Combining_Latin_Small_Letter_M = 0x036B, 						//	U+036B	Combining Latin Small Letter M
+	U_Combining_Latin_Small_Letter_R = 0x036C, 						//	U+036C	Combining Latin Small Letter R
+	U_Combining_Latin_Small_Letter_T = 0x036D, 						//	U+036D	Combining Latin Small Letter T
+	U_Combining_Latin_Small_Letter_V = 0x036E, 						//	U+036E	Combining Latin Small Letter V
+	U_Combining_Latin_Small_Letter_X = 0x036F, 						//	U+036F	Combining Latin Small Letter X
+
+	/**
+	 * Unicode Character 'LINE SEPARATOR' (U+2028)
+	 * http://www.fileformat.info/info/unicode/char/2028/index.htm
+	 */
+	LINE_SEPARATOR_2028 = 8232,
+
+	// http://www.fileformat.info/info/unicode/category/Sk/list.htm
+	U_CIRCUMFLEX = 0x005E,									// U+005E	CIRCUMFLEX
+	U_GRAVE_ACCENT = 0x0060,								// U+0060	GRAVE ACCENT
+	U_DIAERESIS = 0x00A8,									// U+00A8	DIAERESIS
+	U_MACRON = 0x00AF,										// U+00AF	MACRON
+	U_ACUTE_ACCENT = 0x00B4,								// U+00B4	ACUTE ACCENT
+	U_CEDILLA = 0x00B8,										// U+00B8	CEDILLA
+	U_MODIFIER_LETTER_LEFT_ARROWHEAD = 0x02C2,				// U+02C2	MODIFIER LETTER LEFT ARROWHEAD
+	U_MODIFIER_LETTER_RIGHT_ARROWHEAD = 0x02C3,				// U+02C3	MODIFIER LETTER RIGHT ARROWHEAD
+	U_MODIFIER_LETTER_UP_ARROWHEAD = 0x02C4,				// U+02C4	MODIFIER LETTER UP ARROWHEAD
+	U_MODIFIER_LETTER_DOWN_ARROWHEAD = 0x02C5,				// U+02C5	MODIFIER LETTER DOWN ARROWHEAD
+	U_MODIFIER_LETTER_CENTRED_RIGHT_HALF_RING = 0x02D2,		// U+02D2	MODIFIER LETTER CENTRED RIGHT HALF RING
+	U_MODIFIER_LETTER_CENTRED_LEFT_HALF_RING = 0x02D3,		// U+02D3	MODIFIER LETTER CENTRED LEFT HALF RING
+	U_MODIFIER_LETTER_UP_TACK = 0x02D4,						// U+02D4	MODIFIER LETTER UP TACK
+	U_MODIFIER_LETTER_DOWN_TACK = 0x02D5,					// U+02D5	MODIFIER LETTER DOWN TACK
+	U_MODIFIER_LETTER_PLUS_SIGN = 0x02D6,					// U+02D6	MODIFIER LETTER PLUS SIGN
+	U_MODIFIER_LETTER_MINUS_SIGN = 0x02D7,					// U+02D7	MODIFIER LETTER MINUS SIGN
+	U_BREVE = 0x02D8,										// U+02D8	BREVE
+	U_DOT_ABOVE = 0x02D9,									// U+02D9	DOT ABOVE
+	U_RING_ABOVE = 0x02DA,									// U+02DA	RING ABOVE
+	U_OGONEK = 0x02DB,										// U+02DB	OGONEK
+	U_SMALL_TILDE = 0x02DC,									// U+02DC	SMALL TILDE
+	U_DOUBLE_ACUTE_ACCENT = 0x02DD,							// U+02DD	DOUBLE ACUTE ACCENT
+	U_MODIFIER_LETTER_RHOTIC_HOOK = 0x02DE,					// U+02DE	MODIFIER LETTER RHOTIC HOOK
+	U_MODIFIER_LETTER_CROSS_ACCENT = 0x02DF,				// U+02DF	MODIFIER LETTER CROSS ACCENT
+	U_MODIFIER_LETTER_EXTRA_HIGH_TONE_BAR = 0x02E5,			// U+02E5	MODIFIER LETTER EXTRA-HIGH TONE BAR
+	U_MODIFIER_LETTER_HIGH_TONE_BAR = 0x02E6,				// U+02E6	MODIFIER LETTER HIGH TONE BAR
+	U_MODIFIER_LETTER_MID_TONE_BAR = 0x02E7,				// U+02E7	MODIFIER LETTER MID TONE BAR
+	U_MODIFIER_LETTER_LOW_TONE_BAR = 0x02E8,				// U+02E8	MODIFIER LETTER LOW TONE BAR
+	U_MODIFIER_LETTER_EXTRA_LOW_TONE_BAR = 0x02E9,			// U+02E9	MODIFIER LETTER EXTRA-LOW TONE BAR
+	U_MODIFIER_LETTER_YIN_DEPARTING_TONE_MARK = 0x02EA,		// U+02EA	MODIFIER LETTER YIN DEPARTING TONE MARK
+	U_MODIFIER_LETTER_YANG_DEPARTING_TONE_MARK = 0x02EB,	// U+02EB	MODIFIER LETTER YANG DEPARTING TONE MARK
+	U_MODIFIER_LETTER_UNASPIRATED = 0x02ED,					// U+02ED	MODIFIER LETTER UNASPIRATED
+	U_MODIFIER_LETTER_LOW_DOWN_ARROWHEAD = 0x02EF,			// U+02EF	MODIFIER LETTER LOW DOWN ARROWHEAD
+	U_MODIFIER_LETTER_LOW_UP_ARROWHEAD = 0x02F0,			// U+02F0	MODIFIER LETTER LOW UP ARROWHEAD
+	U_MODIFIER_LETTER_LOW_LEFT_ARROWHEAD = 0x02F1,			// U+02F1	MODIFIER LETTER LOW LEFT ARROWHEAD
+	U_MODIFIER_LETTER_LOW_RIGHT_ARROWHEAD = 0x02F2,			// U+02F2	MODIFIER LETTER LOW RIGHT ARROWHEAD
+	U_MODIFIER_LETTER_LOW_RING = 0x02F3,					// U+02F3	MODIFIER LETTER LOW RING
+	U_MODIFIER_LETTER_MIDDLE_GRAVE_ACCENT = 0x02F4,			// U+02F4	MODIFIER LETTER MIDDLE GRAVE ACCENT
+	U_MODIFIER_LETTER_MIDDLE_DOUBLE_GRAVE_ACCENT = 0x02F5,	// U+02F5	MODIFIER LETTER MIDDLE DOUBLE GRAVE ACCENT
+	U_MODIFIER_LETTER_MIDDLE_DOUBLE_ACUTE_ACCENT = 0x02F6,	// U+02F6	MODIFIER LETTER MIDDLE DOUBLE ACUTE ACCENT
+	U_MODIFIER_LETTER_LOW_TILDE = 0x02F7,					// U+02F7	MODIFIER LETTER LOW TILDE
+	U_MODIFIER_LETTER_RAISED_COLON = 0x02F8,				// U+02F8	MODIFIER LETTER RAISED COLON
+	U_MODIFIER_LETTER_BEGIN_HIGH_TONE = 0x02F9,				// U+02F9	MODIFIER LETTER BEGIN HIGH TONE
+	U_MODIFIER_LETTER_END_HIGH_TONE = 0x02FA,				// U+02FA	MODIFIER LETTER END HIGH TONE
+	U_MODIFIER_LETTER_BEGIN_LOW_TONE = 0x02FB,				// U+02FB	MODIFIER LETTER BEGIN LOW TONE
+	U_MODIFIER_LETTER_END_LOW_TONE = 0x02FC,				// U+02FC	MODIFIER LETTER END LOW TONE
+	U_MODIFIER_LETTER_SHELF = 0x02FD,						// U+02FD	MODIFIER LETTER SHELF
+	U_MODIFIER_LETTER_OPEN_SHELF = 0x02FE,					// U+02FE	MODIFIER LETTER OPEN SHELF
+	U_MODIFIER_LETTER_LOW_LEFT_ARROW = 0x02FF,				// U+02FF	MODIFIER LETTER LOW LEFT ARROW
+	U_GREEK_LOWER_NUMERAL_SIGN = 0x0375,					// U+0375	GREEK LOWER NUMERAL SIGN
+	U_GREEK_TONOS = 0x0384,									// U+0384	GREEK TONOS
+	U_GREEK_DIALYTIKA_TONOS = 0x0385,						// U+0385	GREEK DIALYTIKA TONOS
+	U_GREEK_KORONIS = 0x1FBD,								// U+1FBD	GREEK KORONIS
+	U_GREEK_PSILI = 0x1FBF,									// U+1FBF	GREEK PSILI
+	U_GREEK_PERISPOMENI = 0x1FC0,							// U+1FC0	GREEK PERISPOMENI
+	U_GREEK_DIALYTIKA_AND_PERISPOMENI = 0x1FC1,				// U+1FC1	GREEK DIALYTIKA AND PERISPOMENI
+	U_GREEK_PSILI_AND_VARIA = 0x1FCD,						// U+1FCD	GREEK PSILI AND VARIA
+	U_GREEK_PSILI_AND_OXIA = 0x1FCE,						// U+1FCE	GREEK PSILI AND OXIA
+	U_GREEK_PSILI_AND_PERISPOMENI = 0x1FCF,					// U+1FCF	GREEK PSILI AND PERISPOMENI
+	U_GREEK_DASIA_AND_VARIA = 0x1FDD,						// U+1FDD	GREEK DASIA AND VARIA
+	U_GREEK_DASIA_AND_OXIA = 0x1FDE,						// U+1FDE	GREEK DASIA AND OXIA
+	U_GREEK_DASIA_AND_PERISPOMENI = 0x1FDF,					// U+1FDF	GREEK DASIA AND PERISPOMENI
+	U_GREEK_DIALYTIKA_AND_VARIA = 0x1FED,					// U+1FED	GREEK DIALYTIKA AND VARIA
+	U_GREEK_DIALYTIKA_AND_OXIA = 0x1FEE,					// U+1FEE	GREEK DIALYTIKA AND OXIA
+	U_GREEK_VARIA = 0x1FEF,									// U+1FEF	GREEK VARIA
+	U_GREEK_OXIA = 0x1FFD,									// U+1FFD	GREEK OXIA
+	U_GREEK_DASIA = 0x1FFE,									// U+1FFE	GREEK DASIA
+
+
+	U_OVERLINE = 0x203E, // Unicode Character 'OVERLINE'
+
+	/**
+	 * UTF-8 BOM
+	 * Unicode Character 'ZERO WIDTH NO-BREAK SPACE' (U+FEFF)
+	 * http://www.fileformat.info/info/unicode/char/feff/index.htm
+	 */
+	UTF8_BOM = 65279
+}

--- a/src/vs/base/common/comparers.ts
+++ b/src/vs/base/common/comparers.ts
@@ -1,0 +1,197 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import * as strings from './strings';
+import * as paths from './paths';
+
+let intlFileNameCollator: Intl.Collator;
+let intlFileNameCollatorIsNumeric: boolean;
+
+export function setFileNameComparer(collator: Intl.Collator): void {
+	intlFileNameCollator = collator;
+	intlFileNameCollatorIsNumeric = collator.resolvedOptions().numeric;
+}
+
+export function compareFileNames(one: string, other: string, caseSensitive = false): number {
+	if (intlFileNameCollator) {
+		const a = one || '';
+		const b = other || '';
+		const result = intlFileNameCollator.compare(a, b);
+
+		// Using the numeric option in the collator will
+		// make compare(`foo1`, `foo01`) === 0. We must disambiguate.
+		if (intlFileNameCollatorIsNumeric && result === 0 && a !== b) {
+			return a < b ? -1 : 1;
+		}
+
+		return result;
+	}
+
+	return noIntlCompareFileNames(one, other, caseSensitive);
+}
+
+const FileNameMatch = /^(.*?)(\.([^.]*))?$/;
+
+export function noIntlCompareFileNames(one: string, other: string, caseSensitive = false): number {
+	if (!caseSensitive) {
+		one = one && one.toLowerCase();
+		other = other && other.toLowerCase();
+	}
+
+	const [oneName, oneExtension] = extractNameAndExtension(one);
+	const [otherName, otherExtension] = extractNameAndExtension(other);
+
+	if (oneName !== otherName) {
+		return oneName < otherName ? -1 : 1;
+	}
+
+	if (oneExtension === otherExtension) {
+		return 0;
+	}
+
+	return oneExtension < otherExtension ? -1 : 1;
+}
+
+export function compareFileExtensions(one: string, other: string): number {
+	if (intlFileNameCollator) {
+		const [oneName, oneExtension] = extractNameAndExtension(one);
+		const [otherName, otherExtension] = extractNameAndExtension(other);
+
+		let result = intlFileNameCollator.compare(oneExtension, otherExtension);
+
+		if (result === 0) {
+			// Using the numeric option in the collator will
+			// make compare(`foo1`, `foo01`) === 0. We must disambiguate.
+			if (intlFileNameCollatorIsNumeric && oneExtension !== otherExtension) {
+				return oneExtension < otherExtension ? -1 : 1;
+			}
+
+			// Extensions are equal, compare filenames
+			result = intlFileNameCollator.compare(oneName, otherName);
+
+			if (intlFileNameCollatorIsNumeric && result === 0 && oneName !== otherName) {
+				return oneName < otherName ? -1 : 1;
+			}
+		}
+
+		return result;
+	}
+
+	return noIntlCompareFileExtensions(one, other);
+}
+
+function noIntlCompareFileExtensions(one: string, other: string): number {
+	const [oneName, oneExtension] = extractNameAndExtension(one && one.toLowerCase());
+	const [otherName, otherExtension] = extractNameAndExtension(other && other.toLowerCase());
+
+	if (oneExtension !== otherExtension) {
+		return oneExtension < otherExtension ? -1 : 1;
+	}
+
+	if (oneName === otherName) {
+		return 0;
+	}
+
+	return oneName < otherName ? -1 : 1;
+}
+
+function extractNameAndExtension(str?: string): [string, string] {
+	const match = str ? FileNameMatch.exec(str) as Array<string> : ([] as Array<string>);
+
+	return [(match && match[1]) || '', (match && match[3]) || ''];
+}
+
+function comparePathComponents(one: string, other: string, caseSensitive = false): number {
+	if (!caseSensitive) {
+		one = one && one.toLowerCase();
+		other = other && other.toLowerCase();
+	}
+
+	if (one === other) {
+		return 0;
+	}
+
+	return one < other ? -1 : 1;
+}
+
+export function comparePaths(one: string, other: string, caseSensitive = false): number {
+	const oneParts = one.split(paths.nativeSep);
+	const otherParts = other.split(paths.nativeSep);
+
+	const lastOne = oneParts.length - 1;
+	const lastOther = otherParts.length - 1;
+	let endOne: boolean, endOther: boolean;
+
+	for (let i = 0; ; i++) {
+		endOne = lastOne === i;
+		endOther = lastOther === i;
+
+		if (endOne && endOther) {
+			return compareFileNames(oneParts[i], otherParts[i], caseSensitive);
+		} else if (endOne) {
+			return -1;
+		} else if (endOther) {
+			return 1;
+		}
+
+		const result = comparePathComponents(oneParts[i], otherParts[i], caseSensitive);
+
+		if (result !== 0) {
+			return result;
+		}
+	}
+}
+
+export function compareAnything(one: string, other: string, lookFor: string): number {
+	let elementAName = one.toLowerCase();
+	let elementBName = other.toLowerCase();
+
+	// Sort prefix matches over non prefix matches
+	const prefixCompare = compareByPrefix(one, other, lookFor);
+	if (prefixCompare) {
+		return prefixCompare;
+	}
+
+	// Sort suffix matches over non suffix matches
+	let elementASuffixMatch = strings.endsWith(elementAName, lookFor);
+	let elementBSuffixMatch = strings.endsWith(elementBName, lookFor);
+	if (elementASuffixMatch !== elementBSuffixMatch) {
+		return elementASuffixMatch ? -1 : 1;
+	}
+
+	// Understand file names
+	let r = compareFileNames(elementAName, elementBName);
+	if (r !== 0) {
+		return r;
+	}
+
+	// Compare by name
+	return elementAName.localeCompare(elementBName);
+}
+
+export function compareByPrefix(one: string, other: string, lookFor: string): number {
+	let elementAName = one.toLowerCase();
+	let elementBName = other.toLowerCase();
+
+	// Sort prefix matches over non prefix matches
+	let elementAPrefixMatch = strings.startsWith(elementAName, lookFor);
+	let elementBPrefixMatch = strings.startsWith(elementBName, lookFor);
+	if (elementAPrefixMatch !== elementBPrefixMatch) {
+		return elementAPrefixMatch ? -1 : 1;
+	}
+
+	// Same prefix: Sort shorter matches to the top to have those on top that match more precisely
+	else if (elementAPrefixMatch && elementBPrefixMatch) {
+		if (elementAName.length < elementBName.length) {
+			return -1;
+		}
+
+		if (elementAName.length > elementBName.length) {
+			return 1;
+		}
+	}
+
+	return 0;
+}

--- a/src/vs/base/common/filters.ts
+++ b/src/vs/base/common/filters.ts
@@ -1,0 +1,774 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CharCode } from './charCode';
+import { LRUCache } from './map';
+import * as strings from './strings';
+
+export interface IFilter {
+	// Returns null if word doesn't match.
+	(word: string, wordToMatchAgainst: string): IMatch[] | null;
+}
+
+export interface IMatch {
+	start: number;
+	end: number;
+}
+
+// Combined filters
+
+/**
+ * @returns A filter which combines the provided set
+ * of filters with an or. The *first* filters that
+ * matches defined the return value of the returned
+ * filter.
+ */
+export function or(...filter: IFilter[]): IFilter {
+	return function (word: string, wordToMatchAgainst: string): IMatch[] | null {
+		for (let i = 0, len = filter.length; i < len; i++) {
+			let match = filter[i](word, wordToMatchAgainst);
+			if (match) {
+				return match;
+			}
+		}
+		return null;
+	};
+}
+
+// Prefix
+
+export const matchesStrictPrefix: IFilter = _matchesPrefix.bind(undefined, false);
+export const matchesPrefix: IFilter = _matchesPrefix.bind(undefined, true);
+
+function _matchesPrefix(ignoreCase: boolean, word: string, wordToMatchAgainst: string): IMatch[] | null {
+	if (!wordToMatchAgainst || wordToMatchAgainst.length < word.length) {
+		return null;
+	}
+
+	let matches: boolean;
+	if (ignoreCase) {
+		matches = strings.startsWithIgnoreCase(wordToMatchAgainst, word);
+	} else {
+		matches = wordToMatchAgainst.indexOf(word) === 0;
+	}
+
+	if (!matches) {
+		return null;
+	}
+
+	return word.length > 0 ? [{ start: 0, end: word.length }] : [];
+}
+
+// Contiguous Substring
+
+export function matchesContiguousSubString(word: string, wordToMatchAgainst: string): IMatch[] | null {
+	let index = wordToMatchAgainst.toLowerCase().indexOf(word.toLowerCase());
+	if (index === -1) {
+		return null;
+	}
+
+	return [{ start: index, end: index + word.length }];
+}
+
+// Substring
+
+export function matchesSubString(word: string, wordToMatchAgainst: string): IMatch[] | null {
+	return _matchesSubString(word.toLowerCase(), wordToMatchAgainst.toLowerCase(), 0, 0);
+}
+
+function _matchesSubString(word: string, wordToMatchAgainst: string, i: number, j: number): IMatch[] | null {
+	if (i === word.length) {
+		return [];
+	} else if (j === wordToMatchAgainst.length) {
+		return null;
+	} else {
+		if (word[i] === wordToMatchAgainst[j]) {
+			let result: IMatch[] | null = null;
+			if (result = _matchesSubString(word, wordToMatchAgainst, i + 1, j + 1)) {
+				return join({ start: j, end: j + 1 }, result);
+			}
+			return null;
+		}
+
+		return _matchesSubString(word, wordToMatchAgainst, i, j + 1);
+	}
+}
+
+// CamelCase
+
+function isLower(code: number): boolean {
+	return CharCode.a <= code && code <= CharCode.z;
+}
+
+export function isUpper(code: number): boolean {
+	return CharCode.A <= code && code <= CharCode.Z;
+}
+
+function isNumber(code: number): boolean {
+	return CharCode.Digit0 <= code && code <= CharCode.Digit9;
+}
+
+function isWhitespace(code: number): boolean {
+	return (
+		code === CharCode.Space
+		|| code === CharCode.Tab
+		|| code === CharCode.LineFeed
+		|| code === CharCode.CarriageReturn
+	);
+}
+
+function isAlphanumeric(code: number): boolean {
+	return isLower(code) || isUpper(code) || isNumber(code);
+}
+
+function join(head: IMatch, tail: IMatch[]): IMatch[] {
+	if (tail.length === 0) {
+		tail = [head];
+	} else if (head.end === tail[0].start) {
+		tail[0].start = head.start;
+	} else {
+		tail.unshift(head);
+	}
+	return tail;
+}
+
+function nextAnchor(camelCaseWord: string, start: number): number {
+	for (let i = start; i < camelCaseWord.length; i++) {
+		let c = camelCaseWord.charCodeAt(i);
+		if (isUpper(c) || isNumber(c) || (i > 0 && !isAlphanumeric(camelCaseWord.charCodeAt(i - 1)))) {
+			return i;
+		}
+	}
+	return camelCaseWord.length;
+}
+
+function _matchesCamelCase(word: string, camelCaseWord: string, i: number, j: number): IMatch[] | null {
+	if (i === word.length) {
+		return [];
+	} else if (j === camelCaseWord.length) {
+		return null;
+	} else if (word[i] !== camelCaseWord[j].toLowerCase()) {
+		return null;
+	} else {
+		let result: IMatch[] | null = null;
+		let nextUpperIndex = j + 1;
+		result = _matchesCamelCase(word, camelCaseWord, i + 1, j + 1);
+		while (!result && (nextUpperIndex = nextAnchor(camelCaseWord, nextUpperIndex)) < camelCaseWord.length) {
+			result = _matchesCamelCase(word, camelCaseWord, i + 1, nextUpperIndex);
+			nextUpperIndex++;
+		}
+		return result === null ? null : join({ start: j, end: j + 1 }, result);
+	}
+}
+
+interface ICamelCaseAnalysis {
+	upperPercent: number;
+	lowerPercent: number;
+	alphaPercent: number;
+	numericPercent: number;
+}
+
+// Heuristic to avoid computing camel case matcher for words that don't
+// look like camelCaseWords.
+function analyzeCamelCaseWord(word: string): ICamelCaseAnalysis {
+	let upper = 0, lower = 0, alpha = 0, numeric = 0, code = 0;
+
+	for (let i = 0; i < word.length; i++) {
+		code = word.charCodeAt(i);
+
+		if (isUpper(code)) { upper++; }
+		if (isLower(code)) { lower++; }
+		if (isAlphanumeric(code)) { alpha++; }
+		if (isNumber(code)) { numeric++; }
+	}
+
+	let upperPercent = upper / word.length;
+	let lowerPercent = lower / word.length;
+	let alphaPercent = alpha / word.length;
+	let numericPercent = numeric / word.length;
+
+	return { upperPercent, lowerPercent, alphaPercent, numericPercent };
+}
+
+function isUpperCaseWord(analysis: ICamelCaseAnalysis): boolean {
+	const { upperPercent, lowerPercent } = analysis;
+	return lowerPercent === 0 && upperPercent > 0.6;
+}
+
+function isCamelCaseWord(analysis: ICamelCaseAnalysis): boolean {
+	const { upperPercent, lowerPercent, alphaPercent, numericPercent } = analysis;
+	return lowerPercent > 0.2 && upperPercent < 0.8 && alphaPercent > 0.6 && numericPercent < 0.2;
+}
+
+// Heuristic to avoid computing camel case matcher for words that don't
+// look like camel case patterns.
+function isCamelCasePattern(word: string): boolean {
+	let upper = 0, lower = 0, code = 0, whitespace = 0;
+
+	for (let i = 0; i < word.length; i++) {
+		code = word.charCodeAt(i);
+
+		if (isUpper(code)) { upper++; }
+		if (isLower(code)) { lower++; }
+		if (isWhitespace(code)) { whitespace++; }
+	}
+
+	if ((upper === 0 || lower === 0) && whitespace === 0) {
+		return word.length <= 30;
+	} else {
+		return upper <= 5;
+	}
+}
+
+export function matchesCamelCase(word: string, camelCaseWord: string): IMatch[] | null {
+	if (!camelCaseWord) {
+		return null;
+	}
+
+	camelCaseWord = camelCaseWord.trim();
+
+	if (camelCaseWord.length === 0) {
+		return null;
+	}
+
+	if (!isCamelCasePattern(word)) {
+		return null;
+	}
+
+	if (camelCaseWord.length > 60) {
+		return null;
+	}
+
+	const analysis = analyzeCamelCaseWord(camelCaseWord);
+
+	if (!isCamelCaseWord(analysis)) {
+		if (!isUpperCaseWord(analysis)) {
+			return null;
+		}
+
+		camelCaseWord = camelCaseWord.toLowerCase();
+	}
+
+	let result: IMatch[] | null = null;
+	let i = 0;
+
+	word = word.toLowerCase();
+	while (i < camelCaseWord.length && (result = _matchesCamelCase(word, camelCaseWord, 0, i)) === null) {
+		i = nextAnchor(camelCaseWord, i + 1);
+	}
+
+	return result;
+}
+
+// Matches beginning of words supporting non-ASCII languages
+// If `contiguous` is true then matches word with beginnings of the words in the target. E.g. "pul" will match "Git: Pull"
+// Otherwise also matches sub string of the word with beginnings of the words in the target. E.g. "gp" or "g p" will match "Git: Pull"
+// Useful in cases where the target is words (e.g. command labels)
+
+export function matchesWords(word: string, target: string, contiguous: boolean = false): IMatch[] | null {
+	if (!target || target.length === 0) {
+		return null;
+	}
+
+	let result: IMatch[] | null = null;
+	let i = 0;
+
+	word = word.toLowerCase();
+	target = target.toLowerCase();
+	while (i < target.length && (result = _matchesWords(word, target, 0, i, contiguous)) === null) {
+		i = nextWord(target, i + 1);
+	}
+
+	return result;
+}
+
+function _matchesWords(word: string, target: string, i: number, j: number, contiguous: boolean): IMatch[] | null {
+	if (i === word.length) {
+		return [];
+	} else if (j === target.length) {
+		return null;
+	} else if (word[i] !== target[j]) {
+		return null;
+	} else {
+		let result: IMatch[] | null = null;
+		let nextWordIndex = j + 1;
+		result = _matchesWords(word, target, i + 1, j + 1, contiguous);
+		if (!contiguous) {
+			while (!result && (nextWordIndex = nextWord(target, nextWordIndex)) < target.length) {
+				result = _matchesWords(word, target, i + 1, nextWordIndex, contiguous);
+				nextWordIndex++;
+			}
+		}
+		return result === null ? null : join({ start: j, end: j + 1 }, result);
+	}
+}
+
+function nextWord(word: string, start: number): number {
+	for (let i = start; i < word.length; i++) {
+		let c = word.charCodeAt(i);
+		if (isWhitespace(c) || (i > 0 && isWhitespace(word.charCodeAt(i - 1)))) {
+			return i;
+		}
+	}
+	return word.length;
+}
+
+// Fuzzy
+
+export const fuzzyContiguousFilter = or(matchesPrefix, matchesCamelCase, matchesContiguousSubString);
+const fuzzySeparateFilter = or(matchesPrefix, matchesCamelCase, matchesSubString);
+const fuzzyRegExpCache = new LRUCache<string, RegExp>(10000); // bounded to 10000 elements
+
+export function matchesFuzzy(word: string, wordToMatchAgainst: string, enableSeparateSubstringMatching = false): IMatch[] | null {
+	if (typeof word !== 'string' || typeof wordToMatchAgainst !== 'string') {
+		return null; // return early for invalid input
+	}
+
+	// Form RegExp for wildcard matches
+	let regexp = fuzzyRegExpCache.get(word);
+	if (!regexp) {
+		regexp = new RegExp(strings.convertSimple2RegExpPattern(word), 'i');
+		fuzzyRegExpCache.set(word, regexp);
+	}
+
+	// RegExp Filter
+	let match = regexp.exec(wordToMatchAgainst);
+	if (match) {
+		return [{ start: match.index, end: match.index + match[0].length }];
+	}
+
+	// Default Filter
+	return enableSeparateSubstringMatching ? fuzzySeparateFilter(word, wordToMatchAgainst) : fuzzyContiguousFilter(word, wordToMatchAgainst);
+}
+
+export function anyScore(pattern: string, word: string, patternMaxWhitespaceIgnore?: number): FuzzyScore {
+	pattern = pattern.toLowerCase();
+	word = word.toLowerCase();
+
+	const matches: number[] = [];
+	let idx = 0;
+	for (let pos = 0; pos < pattern.length; ++pos) {
+		const thisIdx = word.indexOf(pattern.charAt(pos), idx);
+		if (thisIdx >= 0) {
+			matches.push(thisIdx);
+			idx = thisIdx + 1;
+		}
+	}
+	return [matches.length, matches];
+}
+
+//#region --- fuzzyScore ---
+
+export function createMatches(offsetOrScore: number[] | FuzzyScore): IMatch[] {
+	let ret: IMatch[] = [];
+	if (!offsetOrScore) {
+		return ret;
+	}
+	let offsets: number[];
+	if (Array.isArray(offsetOrScore[1])) {
+		offsets = (offsetOrScore as FuzzyScore)[1];
+	} else {
+		offsets = offsetOrScore as number[];
+	}
+	let last: IMatch | undefined;
+	for (const pos of offsets) {
+		if (last && last.end === pos) {
+			last.end += 1;
+		} else {
+			last = { start: pos, end: pos + 1 };
+			ret.push(last);
+		}
+	}
+	return ret;
+}
+
+function initTable() {
+	const table: number[][] = [];
+	const row: number[] = [0];
+	for (let i = 1; i <= 100; i++) {
+		row.push(-i);
+	}
+	for (let i = 0; i <= 100; i++) {
+		let thisRow = row.slice(0);
+		thisRow[0] = -i;
+		table.push(thisRow);
+	}
+	return table;
+}
+
+const _table = initTable();
+const _scores = initTable();
+const _arrows = <Arrow[][]>initTable();
+const _debug = false;
+
+function printTable(table: number[][], pattern: string, patternLen: number, word: string, wordLen: number): string {
+	function pad(s: string, n: number, pad = ' ') {
+		while (s.length < n) {
+			s = pad + s;
+		}
+		return s;
+	}
+	let ret = ` |   |${word.split('').map(c => pad(c, 3)).join('|')}\n`;
+
+	for (let i = 0; i <= patternLen; i++) {
+		if (i === 0) {
+			ret += ' |';
+		} else {
+			ret += `${pattern[i - 1]}|`;
+		}
+		ret += table[i].slice(0, wordLen + 1).map(n => pad(n.toString(), 3)).join('|') + '\n';
+	}
+	return ret;
+}
+
+function isSeparatorAtPos(value: string, index: number): boolean {
+	if (index < 0 || index >= value.length) {
+		return false;
+	}
+	const code = value.charCodeAt(index);
+	switch (code) {
+		case CharCode.Underline:
+		case CharCode.Dash:
+		case CharCode.Period:
+		case CharCode.Space:
+		case CharCode.Slash:
+		case CharCode.Backslash:
+		case CharCode.SingleQuote:
+		case CharCode.DoubleQuote:
+		case CharCode.Colon:
+			return true;
+		default:
+			return false;
+	}
+}
+
+function isWhitespaceAtPos(value: string, index: number): boolean {
+	if (index < 0 || index >= value.length) {
+		return false;
+	}
+	const code = value.charCodeAt(index);
+	switch (code) {
+		case CharCode.Space:
+		case CharCode.Tab:
+			return true;
+		default:
+			return false;
+	}
+}
+
+const enum Arrow { Top = 0b1, Diag = 0b10, Left = 0b100 }
+
+export type FuzzyScore = [number, number[]];
+
+export interface FuzzyScorer {
+	(pattern: string, lowPattern: string, patternPos: number, word: string, lowWord: string, wordPos: number, firstMatchCanBeWeak: boolean): FuzzyScore;
+}
+
+export function fuzzyScore(pattern: string, lowPattern: string, patternPos: number, word: string, lowWord: string, wordPos: number, firstMatchCanBeWeak: boolean): FuzzyScore | undefined {
+
+	const patternLen = pattern.length > 100 ? 100 : pattern.length;
+	const wordLen = word.length > 100 ? 100 : word.length;
+
+	if (patternPos >= patternLen || wordPos >= wordLen || patternLen > wordLen) {
+		return undefined;
+	}
+
+	// Run a simple check if the characters of pattern occur
+	// (in order) at all in word. If that isn't the case we
+	// stop because no match will be possible
+	const patternStartPos = patternPos;
+	const wordStartPos = wordPos;
+	while (patternPos < patternLen && wordPos < wordLen) {
+		if (lowPattern[patternPos] === lowWord[wordPos]) {
+			patternPos += 1;
+		}
+		wordPos += 1;
+	}
+	if (patternPos !== patternLen) {
+		return undefined;
+	}
+
+	patternPos = patternStartPos;
+	wordPos = wordStartPos;
+
+	// There will be a mach, fill in tables
+	for (patternPos = patternStartPos + 1; patternPos <= patternLen; patternPos++) {
+
+		for (wordPos = 1; wordPos <= wordLen; wordPos++) {
+
+			let score = -1;
+			let lowWordChar = lowWord[wordPos - 1];
+			if (lowPattern[patternPos - 1] === lowWordChar) {
+				if (wordPos === (patternPos - patternStartPos)) {
+					// common prefix: `foobar <-> foobaz`
+					if (pattern[patternPos - 1] === word[wordPos - 1]) {
+						score = 7;
+					} else {
+						score = 5;
+					}
+				} else if (lowWordChar !== word[wordPos - 1] && (wordPos === 1 || lowWord[wordPos - 2] === word[wordPos - 2])) {
+					// hitting upper-case: `foo <-> forOthers`
+					if (pattern[patternPos - 1] === word[wordPos - 1]) {
+						score = 7;
+					} else {
+						score = 5;
+					}
+				} else if (isSeparatorAtPos(lowWord, wordPos - 2) || isWhitespaceAtPos(lowWord, wordPos - 2)) {
+					// post separator: `foo <-> bar_foo`
+					score = 5;
+
+				} else {
+					score = 1;
+				}
+			}
+
+			_scores[patternPos][wordPos] = score;
+
+			let diag = _table[patternPos - 1][wordPos - 1] + (score > 1 ? 1 : score);
+			let top = _table[patternPos - 1][wordPos] + -1;
+			let left = _table[patternPos][wordPos - 1] + -1;
+
+			if (left >= top) {
+				// left or diag
+				if (left > diag) {
+					_table[patternPos][wordPos] = left;
+					_arrows[patternPos][wordPos] = Arrow.Left;
+				} else if (left === diag) {
+					_table[patternPos][wordPos] = left;
+					_arrows[patternPos][wordPos] = Arrow.Left | Arrow.Diag;
+				} else {
+					_table[patternPos][wordPos] = diag;
+					_arrows[patternPos][wordPos] = Arrow.Diag;
+				}
+			} else {
+				// top or diag
+				if (top > diag) {
+					_table[patternPos][wordPos] = top;
+					_arrows[patternPos][wordPos] = Arrow.Top;
+				} else if (top === diag) {
+					_table[patternPos][wordPos] = top;
+					_arrows[patternPos][wordPos] = Arrow.Top | Arrow.Diag;
+				} else {
+					_table[patternPos][wordPos] = diag;
+					_arrows[patternPos][wordPos] = Arrow.Diag;
+				}
+			}
+		}
+	}
+
+	if (_debug) {
+		console.log(printTable(_table, pattern, patternLen, word, wordLen));
+		console.log(printTable(_arrows, pattern, patternLen, word, wordLen));
+		console.log(printTable(_scores, pattern, patternLen, word, wordLen));
+	}
+
+	// _bucket is an array of [PrefixArray] we use to keep
+	// track of scores and matches. After calling `_findAllMatches`
+	// the best match (if available) is the first item in the array
+	_matchesCount = 0;
+	_topScore = -100;
+	_patternStartPos = patternStartPos;
+	_firstMatchCanBeWeak = firstMatchCanBeWeak;
+	_findAllMatches(patternLen, wordLen, patternLen === wordLen ? 1 : 0, new LazyArray(), false);
+
+	if (_matchesCount === 0) {
+		return undefined;
+	}
+
+	return [_topScore, _topMatch.toArray()];
+}
+
+let _matchesCount: number = 0;
+let _topMatch: LazyArray;
+let _topScore: number = 0;
+let _patternStartPos: number = 0;
+let _firstMatchCanBeWeak: boolean = false;
+
+function _findAllMatches(patternPos: number, wordPos: number, total: number, matches: LazyArray, lastMatched: boolean): void {
+
+	if (_matchesCount >= 10 || total < -25) {
+		// stop when having already 10 results, or
+		// when a potential alignment as already 5 gaps
+		return;
+	}
+
+	let simpleMatchCount = 0;
+
+	while (patternPos > _patternStartPos && wordPos > 0) {
+
+		let score = _scores[patternPos][wordPos];
+		let arrow = _arrows[patternPos][wordPos];
+
+		if (arrow === Arrow.Left) {
+			// left
+			wordPos -= 1;
+			if (lastMatched) {
+				total -= 5; // new gap penalty
+			} else if (!matches.isEmpty()) {
+				total -= 1; // gap penalty after first match
+			}
+			lastMatched = false;
+			simpleMatchCount = 0;
+
+		} else if (arrow & Arrow.Diag) {
+
+			if (arrow & Arrow.Left) {
+				// left
+				_findAllMatches(
+					patternPos,
+					wordPos - 1,
+					!matches.isEmpty() ? total - 1 : total, // gap penalty after first match
+					matches.slice(),
+					lastMatched
+				);
+			}
+
+			// diag
+			total += score;
+			patternPos -= 1;
+			wordPos -= 1;
+			matches.unshift(wordPos);
+			lastMatched = true;
+
+			// count simple matches and boost a row of
+			// simple matches when they yield in a
+			// strong match.
+			if (score === 1) {
+				simpleMatchCount += 1;
+
+				if (patternPos === _patternStartPos && !_firstMatchCanBeWeak) {
+					// when the first match is a weak
+					// match we discard it
+					return undefined;
+				}
+
+			} else {
+				// boost
+				total += 1 + (simpleMatchCount * (score - 1));
+				simpleMatchCount = 0;
+			}
+
+		} else {
+			return undefined;
+		}
+	}
+
+	total -= wordPos >= 3 ? 9 : wordPos * 3; // late start penalty
+
+	// dynamically keep track of the current top score
+	// and insert the current best score at head, the rest at tail
+	_matchesCount += 1;
+	if (total > _topScore) {
+		_topScore = total;
+		_topMatch = matches;
+	}
+}
+
+class LazyArray {
+
+	private _parent: LazyArray = new LazyArray;
+	private _parentLen: number = 0;
+	private _data: number[] = [];
+
+	isEmpty(): boolean {
+		return (!this._data || this._data.length === 0) && (!this._parent || this._parent.isEmpty());
+	}
+
+	unshift(n: number) {
+		if (!this._data) {
+			this._data = [n];
+		} else {
+			this._data.unshift(n);
+		}
+	}
+
+	slice(): LazyArray {
+		const ret = new LazyArray();
+		ret._parent = this;
+		ret._parentLen = this._data ? this._data.length : 0; return ret;
+	}
+
+	toArray(): number[] {
+		if (!this._data || this._data.length === 0) {
+			return this._parent.toArray();
+		}
+		const bucket: number[][] = [];
+		let element = <LazyArray>this;
+		while (element) {
+			if (element._parent && element._parent._data) {
+				bucket.push(element._parent._data.slice(element._parent._data.length - element._parentLen));
+			}
+			element = element._parent;
+		}
+		return Array.prototype.concat.apply(this._data, bucket);
+	}
+}
+
+//#endregion
+
+
+//#region --- graceful ---
+
+export function fuzzyScoreGracefulAggressive(pattern: string, lowPattern: string, patternPos: number, word: string, lowWord: string, wordPos: number, firstMatchCanBeWeak: boolean): FuzzyScore | undefined {
+	return fuzzyScoreWithPermutations(pattern, lowPattern, patternPos, word, lowWord, wordPos, true, firstMatchCanBeWeak);
+}
+
+export function fuzzyScoreGraceful(pattern: string, lowPattern: string, patternPos: number, word: string, lowWord: string, wordPos: number, firstMatchCanBeWeak: boolean): FuzzyScore | undefined {
+	return fuzzyScoreWithPermutations(pattern, lowPattern, patternPos, word, lowWord, wordPos, false, firstMatchCanBeWeak);
+}
+
+function fuzzyScoreWithPermutations(pattern: string, lowPattern: string, patternPos: number, word: string, lowWord: string, wordPos: number, aggressive: boolean, firstMatchCanBeWeak: boolean): FuzzyScore | undefined {
+	let top = fuzzyScore(pattern, lowPattern, patternPos, word, lowWord, wordPos, firstMatchCanBeWeak);
+
+	if (top && !aggressive) {
+		// when using the original pattern yield a result we`
+		// return it unless we are aggressive and try to find
+		// a better alignment, e.g. `cno` -> `^co^ns^ole` or `^c^o^nsole`.
+		return top;
+	}
+
+	if (pattern.length >= 3) {
+		// When the pattern is long enough then try a few (max 7)
+		// permutations of the pattern to find a better match. The
+		// permutations only swap neighbouring characters, e.g
+		// `cnoso` becomes `conso`, `cnsoo`, `cnoos`.
+		let tries = Math.min(7, pattern.length - 1);
+		for (let movingPatternPos = patternPos + 1; movingPatternPos < tries; movingPatternPos++) {
+			let newPattern = nextTypoPermutation(pattern, movingPatternPos);
+			if (newPattern) {
+				let candidate = fuzzyScore(newPattern, newPattern.toLowerCase(), patternPos, word, lowWord, wordPos, firstMatchCanBeWeak);
+				if (candidate) {
+					candidate[0] -= 3; // permutation penalty
+					if (!top || candidate[0] > top[0]) {
+						top = candidate;
+					}
+				}
+			}
+		}
+	}
+
+	return top;
+}
+
+function nextTypoPermutation(pattern: string, patternPos: number): string | undefined {
+
+	if (patternPos + 1 >= pattern.length) {
+		return undefined;
+	}
+
+	let swap1 = pattern[patternPos];
+	let swap2 = pattern[patternPos + 1];
+
+	if (swap1 === swap2) {
+		return undefined;
+	}
+
+	return pattern.slice(0, patternPos)
+		+ swap2
+		+ swap1
+		+ pattern.slice(patternPos + 2);
+}
+
+//#endregion

--- a/src/vs/base/common/map.ts
+++ b/src/vs/base/common/map.ts
@@ -1,0 +1,388 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+interface Item<K, V> {
+	previous: Item<K, V> | undefined;
+	next: Item<K, V> | undefined;
+	key: K;
+	value: V;
+}
+
+export const enum Touch {
+	None = 0,
+	AsOld = 1,
+	AsNew = 2
+}
+
+export class LinkedMap<K, V> {
+
+	private _map: Map<K, Item<K, V>>;
+	private _head: Item<K, V> | undefined;
+	private _tail: Item<K, V> | undefined;
+	private _size: number;
+
+	constructor() {
+		this._map = new Map<K, Item<K, V>>();
+		this._head = undefined;
+		this._tail = undefined;
+		this._size = 0;
+	}
+
+	public clear(): void {
+		this._map.clear();
+		this._head = undefined;
+		this._tail = undefined;
+		this._size = 0;
+	}
+
+	public isEmpty(): boolean {
+		return !this._head && !this._tail;
+	}
+
+	public get size(): number {
+		return this._size;
+	}
+
+	public has(key: K): boolean {
+		return this._map.has(key);
+	}
+
+	public get(key: K, touch: Touch = Touch.None): V | undefined {
+		const item = this._map.get(key);
+		if (!item) {
+			return undefined;
+		}
+		if (touch !== Touch.None) {
+			this.touch(item, touch);
+		}
+		return item.value;
+	}
+
+	public set(key: K, value: V, touch: Touch = Touch.None): void {
+		let item = this._map.get(key);
+		if (item) {
+			item.value = value;
+			if (touch !== Touch.None) {
+				this.touch(item, touch);
+			}
+		} else {
+			item = { key, value, next: undefined, previous: undefined };
+			switch (touch) {
+				case Touch.None:
+					this.addItemLast(item);
+					break;
+				case Touch.AsOld:
+					this.addItemFirst(item);
+					break;
+				case Touch.AsNew:
+					this.addItemLast(item);
+					break;
+				default:
+					this.addItemLast(item);
+					break;
+			}
+			this._map.set(key, item);
+			this._size++;
+		}
+	}
+
+	public delete(key: K): boolean {
+		return !!this.remove(key);
+	}
+
+	public remove(key: K): V | undefined {
+		const item = this._map.get(key);
+		if (!item) {
+			return undefined;
+		}
+		this._map.delete(key);
+		this.removeItem(item);
+		this._size--;
+		return item.value;
+	}
+
+	public shift(): V | undefined {
+		if (!this._head && !this._tail) {
+			return undefined;
+		}
+		if (!this._head || !this._tail) {
+			throw new Error('Invalid list');
+		}
+		const item = this._head;
+		this._map.delete(item.key);
+		this.removeItem(item);
+		this._size--;
+		return item.value;
+	}
+
+	public forEach(callbackfn: (value: V, key: K, map: LinkedMap<K, V>) => void, thisArg?: any): void {
+		let current = this._head;
+		while (current) {
+			if (thisArg) {
+				callbackfn.bind(thisArg)(current.value, current.key, this);
+			} else {
+				callbackfn(current.value, current.key, this);
+			}
+			current = current.next;
+		}
+	}
+
+	public values(): V[] {
+		let result: V[] = [];
+		let current = this._head;
+		while (current) {
+			result.push(current.value);
+			current = current.next;
+		}
+		return result;
+	}
+
+	public keys(): K[] {
+		let result: K[] = [];
+		let current = this._head;
+		while (current) {
+			result.push(current.key);
+			current = current.next;
+		}
+		return result;
+	}
+
+	/* VS Code / Monaco editor runs on es5 which has no Symbol.iterator
+	public keys(): IterableIterator<K> {
+		let current = this._head;
+		let iterator: IterableIterator<K> = {
+			[Symbol.iterator]() {
+				return iterator;
+			},
+			next():IteratorResult<K> {
+				if (current) {
+					let result = { value: current.key, done: false };
+					current = current.next;
+					return result;
+				} else {
+					return { value: undefined, done: true };
+				}
+			}
+		};
+		return iterator;
+	}
+
+	public values(): IterableIterator<V> {
+		let current = this._head;
+		let iterator: IterableIterator<V> = {
+			[Symbol.iterator]() {
+				return iterator;
+			},
+			next():IteratorResult<V> {
+				if (current) {
+					let result = { value: current.value, done: false };
+					current = current.next;
+					return result;
+				} else {
+					return { value: undefined, done: true };
+				}
+			}
+		};
+		return iterator;
+	}
+	*/
+
+	protected trimOld(newSize: number) {
+		if (newSize >= this.size) {
+			return;
+		}
+		if (newSize === 0) {
+			this.clear();
+			return;
+		}
+		let current = this._head;
+		let currentSize = this.size;
+		while (current && currentSize > newSize) {
+			this._map.delete(current.key);
+			current = current.next;
+			currentSize--;
+		}
+		this._head = current;
+		this._size = currentSize;
+		if (current) {
+			current.previous = void 0;
+		}
+	}
+
+	private addItemFirst(item: Item<K, V>): void {
+		// First time Insert
+		if (!this._head && !this._tail) {
+			this._tail = item;
+		} else if (!this._head) {
+			throw new Error('Invalid list');
+		} else {
+			item.next = this._head;
+			this._head.previous = item;
+		}
+		this._head = item;
+	}
+
+	private addItemLast(item: Item<K, V>): void {
+		// First time Insert
+		if (!this._head && !this._tail) {
+			this._head = item;
+		} else if (!this._tail) {
+			throw new Error('Invalid list');
+		} else {
+			item.previous = this._tail;
+			this._tail.next = item;
+		}
+		this._tail = item;
+	}
+
+	private removeItem(item: Item<K, V>): void {
+		if (item === this._head && item === this._tail) {
+			this._head = void 0;
+			this._tail = void 0;
+		}
+		else if (item === this._head) {
+			this._head = item.next;
+		}
+		else if (item === this._tail) {
+			this._tail = item.previous;
+		}
+		else {
+			const next = item.next;
+			const previous = item.previous;
+			if (!next || !previous) {
+				throw new Error('Invalid list');
+			}
+			next.previous = previous;
+			previous.next = next;
+		}
+	}
+
+	private touch(item: Item<K, V>, touch: Touch): void {
+		if (!this._head || !this._tail) {
+			throw new Error('Invalid list');
+		}
+		if ((touch !== Touch.AsOld && touch !== Touch.AsNew)) {
+			return;
+		}
+
+		if (touch === Touch.AsOld) {
+			if (item === this._head) {
+				return;
+			}
+
+			const next = item.next;
+			const previous = item.previous;
+
+			// Unlink the item
+			if (item === this._tail) {
+				// previous must be defined since item was not head but is tail
+				// So there are more than on item in the map
+				previous!.next = void 0;
+				this._tail = previous;
+			}
+			else {
+				// Both next and previous are not undefined since item was neither head nor tail.
+				next!.previous = previous;
+				previous!.next = next;
+			}
+
+			// Insert the node at head
+			item.previous = void 0;
+			item.next = this._head;
+			this._head.previous = item;
+			this._head = item;
+		} else if (touch === Touch.AsNew) {
+			if (item === this._tail) {
+				return;
+			}
+
+			const next = item.next;
+			const previous = item.previous;
+
+			// Unlink the item.
+			if (item === this._head) {
+				// next must be defined since item was not tail but is head
+				// So there are more than on item in the map
+				next!.previous = void 0;
+				this._head = next;
+			} else {
+				// Both next and previous are not undefined since item was neither head nor tail.
+				next!.previous = previous;
+				previous!.next = next;
+			}
+			item.next = void 0;
+			item.previous = this._tail;
+			this._tail.next = item;
+			this._tail = item;
+		}
+	}
+
+	public toJSON(): [K, V][] {
+		const data: [K, V][] = [];
+
+		this.forEach((value, key) => {
+			data.push([key, value]);
+		});
+
+		return data;
+	}
+
+	public fromJSON(data: [K, V][]): void {
+		this.clear();
+
+		for (const [key, value] of data) {
+			this.set(key, value);
+		}
+	}
+}
+
+export class LRUCache<K, V> extends LinkedMap<K, V> {
+
+	private _limit: number;
+	private _ratio: number;
+
+	constructor(limit: number, ratio: number = 1) {
+		super();
+		this._limit = limit;
+		this._ratio = Math.min(Math.max(0, ratio), 1);
+	}
+
+	public get limit(): number {
+		return this._limit;
+	}
+
+	public set limit(limit: number) {
+		this._limit = limit;
+		this.checkTrim();
+	}
+
+	public get ratio(): number {
+		return this._ratio;
+	}
+
+	public set ratio(ratio: number) {
+		this._ratio = Math.min(Math.max(0, ratio), 1);
+		this.checkTrim();
+	}
+
+	public get(key: K): V | undefined {
+		return super.get(key, Touch.AsNew);
+	}
+
+	public peek(key: K): V | undefined {
+		return super.get(key, Touch.None);
+	}
+
+	public set(key: K, value: V): void {
+		super.set(key, value, Touch.AsNew);
+		this.checkTrim();
+	}
+
+	private checkTrim() {
+		if (this.size > this._limit) {
+			this.trimOld(Math.round(this._limit * this._ratio));
+		}
+	}
+}

--- a/src/vs/base/common/paths.ts
+++ b/src/vs/base/common/paths.ts
@@ -1,0 +1,402 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { isWindows } from './platform';
+import { startsWithIgnoreCase, equalsIgnoreCase } from './strings';
+import { CharCode } from './charCode';
+
+/**
+ * The forward slash path separator.
+ */
+export const sep = '/';
+
+/**
+ * The native path separator depending on the OS.
+ */
+export const nativeSep = isWindows ? '\\' : '/';
+
+/**
+ * @param path the path to get the dirname from
+ * @param separator the separator to use
+ * @returns the directory name of a path.
+ *
+ */
+export function dirname(path: string, separator = nativeSep): string {
+	const idx = ~path.lastIndexOf('/') || ~path.lastIndexOf('\\');
+	if (idx === 0) {
+		return '.';
+	} else if (~idx === 0) {
+		return path[0];
+	} else if (~idx === path.length - 1) {
+		return dirname(path.substring(0, path.length - 1));
+	} else {
+		let res = path.substring(0, ~idx);
+		if (isWindows && res[res.length - 1] === ':') {
+			res += separator; // make sure drive letters end with backslash
+		}
+		return res;
+	}
+}
+
+/**
+ * @returns the base name of a path.
+ */
+export function basename(path: string): string {
+	const idx = ~path.lastIndexOf('/') || ~path.lastIndexOf('\\');
+	if (idx === 0) {
+		return path;
+	} else if (~idx === path.length - 1) {
+		return basename(path.substring(0, path.length - 1));
+	} else {
+		return path.substr(~idx + 1);
+	}
+}
+
+/**
+ * @returns `.far` from `boo.far` or the empty string.
+ */
+export function extname(path: string): string {
+	path = basename(path);
+	const idx = ~path.lastIndexOf('.');
+	return idx ? path.substring(~idx) : '';
+}
+
+const _posixBadPath = /(\/\.\.?\/)|(\/\.\.?)$|^(\.\.?\/)|(\/\/+)|(\\)/;
+const _winBadPath = /(\\\.\.?\\)|(\\\.\.?)$|^(\.\.?\\)|(\\\\+)|(\/)/;
+
+function _isNormal(path: string, win: boolean): boolean {
+	return win
+		? !_winBadPath.test(path)
+		: !_posixBadPath.test(path);
+}
+
+export function normalize(path: string, toOSPath?: boolean): string {
+
+	if (path === null || path === void 0) {
+		return path;
+	}
+
+	const len = path.length;
+	if (len === 0) {
+		return '.';
+	}
+
+	const wantsBackslash = !!(isWindows && toOSPath);
+	if (_isNormal(path, wantsBackslash)) {
+		return path;
+	}
+
+	const sep = wantsBackslash ? '\\' : '/';
+	const root = getRoot(path, sep);
+
+	// skip the root-portion of the path
+	let start = root.length;
+	let skip = false;
+	let res = '';
+
+	for (let end = root.length; end <= len; end++) {
+
+		// either at the end or at a path-separator character
+		if (end === len || path.charCodeAt(end) === CharCode.Slash || path.charCodeAt(end) === CharCode.Backslash) {
+
+			if (streql(path, start, end, '..')) {
+				// skip current and remove parent (if there is already something)
+				let prev_start = res.lastIndexOf(sep);
+				let prev_part = res.slice(prev_start + 1);
+				if ((root || prev_part.length > 0) && prev_part !== '..') {
+					res = prev_start === -1 ? '' : res.slice(0, prev_start);
+					skip = true;
+				}
+			} else if (streql(path, start, end, '.') && (root || res || end < len - 1)) {
+				// skip current (if there is already something or if there is more to come)
+				skip = true;
+			}
+
+			if (!skip) {
+				let part = path.slice(start, end);
+				if (res !== '' && res[res.length - 1] !== sep) {
+					res += sep;
+				}
+				res += part;
+			}
+			start = end + 1;
+			skip = false;
+		}
+	}
+
+	return root + res;
+}
+
+function streql(value: string, start: number, end: number, other: string): boolean {
+	return start + other.length === end && value.indexOf(other, start) === start;
+}
+
+/**
+ * Computes the _root_ this path, like `getRoot('c:\files') === c:\`,
+ * `getRoot('files:///files/path') === files:///`,
+ * or `getRoot('\\server\shares\path') === \\server\shares\`
+ */
+export function getRoot(path: string, sep: string = '/'): string {
+
+	if (!path) {
+		return '';
+	}
+
+	let len = path.length;
+	let code = path.charCodeAt(0);
+	if (code === CharCode.Slash || code === CharCode.Backslash) {
+
+		code = path.charCodeAt(1);
+		if (code === CharCode.Slash || code === CharCode.Backslash) {
+			// UNC candidate \\localhost\shares\ddd
+			//               ^^^^^^^^^^^^^^^^^^^
+			code = path.charCodeAt(2);
+			if (code !== CharCode.Slash && code !== CharCode.Backslash) {
+				let pos = 3;
+				let start = pos;
+				for (; pos < len; pos++) {
+					code = path.charCodeAt(pos);
+					if (code === CharCode.Slash || code === CharCode.Backslash) {
+						break;
+					}
+				}
+				code = path.charCodeAt(pos + 1);
+				if (start !== pos && code !== CharCode.Slash && code !== CharCode.Backslash) {
+					pos += 1;
+					for (; pos < len; pos++) {
+						code = path.charCodeAt(pos);
+						if (code === CharCode.Slash || code === CharCode.Backslash) {
+							return path.slice(0, pos + 1) // consume this separator
+								.replace(/[\\/]/g, sep);
+						}
+					}
+				}
+			}
+		}
+
+		// /user/far
+		// ^
+		return sep;
+
+	} else if ((code >= CharCode.A && code <= CharCode.Z) || (code >= CharCode.a && code <= CharCode.z)) {
+		// check for windows drive letter c:\ or c:
+
+		if (path.charCodeAt(1) === CharCode.Colon) {
+			code = path.charCodeAt(2);
+			if (code === CharCode.Slash || code === CharCode.Backslash) {
+				// C:\fff
+				// ^^^
+				return path.slice(0, 2) + sep;
+			} else {
+				// C:
+				// ^^
+				return path.slice(0, 2);
+			}
+		}
+	}
+
+	// check for URI
+	// scheme://authority/path
+	// ^^^^^^^^^^^^^^^^^^^
+	let pos = path.indexOf('://');
+	if (pos !== -1) {
+		pos += 3; // 3 -> "://".length
+		for (; pos < len; pos++) {
+			code = path.charCodeAt(pos);
+			if (code === CharCode.Slash || code === CharCode.Backslash) {
+				return path.slice(0, pos + 1); // consume this separator
+			}
+		}
+	}
+
+	return '';
+}
+
+export const join: (...parts: string[]) => string = function () {
+	// Not using a function with var-args because of how TS compiles
+	// them to JS - it would result in 2*n runtime cost instead
+	// of 1*n, where n is parts.length.
+
+	let value = '';
+	for (let i = 0; i < arguments.length; i++) {
+		let part = arguments[i];
+		if (i > 0) {
+			// add the separater between two parts unless
+			// there already is one
+			let last = value.charCodeAt(value.length - 1);
+			if (last !== CharCode.Slash && last !== CharCode.Backslash) {
+				let next = part.charCodeAt(0);
+				if (next !== CharCode.Slash && next !== CharCode.Backslash) {
+
+					value += sep;
+				}
+			}
+		}
+		value += part;
+	}
+
+	return normalize(value);
+};
+
+
+/**
+ * Check if the path follows this pattern: `\\hostname\sharename`.
+ *
+ * @see https://msdn.microsoft.com/en-us/library/gg465305.aspx
+ * @return A boolean indication if the path is a UNC path, on none-windows
+ * always false.
+ */
+export function isUNC(path: string): boolean {
+	if (!isWindows) {
+		// UNC is a windows concept
+		return false;
+	}
+
+	if (!path || path.length < 5) {
+		// at least \\a\b
+		return false;
+	}
+
+	let code = path.charCodeAt(0);
+	if (code !== CharCode.Backslash) {
+		return false;
+	}
+	code = path.charCodeAt(1);
+	if (code !== CharCode.Backslash) {
+		return false;
+	}
+	let pos = 2;
+	let start = pos;
+	for (; pos < path.length; pos++) {
+		code = path.charCodeAt(pos);
+		if (code === CharCode.Backslash) {
+			break;
+		}
+	}
+	if (start === pos) {
+		return false;
+	}
+	code = path.charCodeAt(pos + 1);
+	if (isNaN(code) || code === CharCode.Backslash) {
+		return false;
+	}
+	return true;
+}
+
+// Reference: https://en.wikipedia.org/wiki/Filename
+const INVALID_FILE_CHARS = isWindows ? /[\\/:\*\?"<>\|]/g : /[\\/]/g;
+const WINDOWS_FORBIDDEN_NAMES = /^(con|prn|aux|clock\$|nul|lpt[0-9]|com[0-9])$/i;
+export function isValidBasename(name: string): boolean {
+	if (!name || name.length === 0 || /^\s+$/.test(name)) {
+		return false; // require a name that is not just whitespace
+	}
+
+	INVALID_FILE_CHARS.lastIndex = 0; // the holy grail of software development
+	if (INVALID_FILE_CHARS.test(name)) {
+		return false; // check for certain invalid file characters
+	}
+
+	if (isWindows && WINDOWS_FORBIDDEN_NAMES.test(name)) {
+		return false; // check for certain invalid file names
+	}
+
+	if (name === '.' || name === '..') {
+		return false; // check for reserved values
+	}
+
+	if (isWindows && name[name.length - 1] === '.') {
+		return false; // Windows: file cannot end with a "."
+	}
+
+	if (isWindows && name.length !== name.trim().length) {
+		return false; // Windows: file cannot end with a whitespace
+	}
+
+	return true;
+}
+
+export function isEqual(pathA: string, pathB: string, ignoreCase?: boolean): boolean {
+	const identityEquals = (pathA === pathB);
+	if (!ignoreCase || identityEquals) {
+		return identityEquals;
+	}
+
+	if (!pathA || !pathB) {
+		return false;
+	}
+
+	return equalsIgnoreCase(pathA, pathB);
+}
+
+export function isEqualOrParent(path: string, candidate: string, ignoreCase?: boolean, separator = nativeSep): boolean {
+	if (path === candidate) {
+		return true;
+	}
+
+	if (!path || !candidate) {
+		return false;
+	}
+
+	if (candidate.length > path.length) {
+		return false;
+	}
+
+	if (ignoreCase) {
+		const beginsWith = startsWithIgnoreCase(path, candidate);
+		if (!beginsWith) {
+			return false;
+		}
+
+		if (candidate.length === path.length) {
+			return true; // same path, different casing
+		}
+
+		let sepOffset = candidate.length;
+		if (candidate.charAt(candidate.length - 1) === separator) {
+			sepOffset--; // adjust the expected sep offset in case our candidate already ends in separator character
+		}
+
+		return path.charAt(sepOffset) === separator;
+	}
+
+	if (candidate.charAt(candidate.length - 1) !== separator) {
+		candidate += separator;
+	}
+
+	return path.indexOf(candidate) === 0;
+}
+
+/**
+ * Adapted from Node's path.isAbsolute functions
+ */
+export function isAbsolute(path: string): boolean {
+	return isWindows ?
+		isAbsolute_win32(path) :
+		isAbsolute_posix(path);
+}
+
+export function isAbsolute_win32(path: string): boolean {
+	if (!path) {
+		return false;
+	}
+
+	const char0 = path.charCodeAt(0);
+	if (char0 === CharCode.Slash || char0 === CharCode.Backslash) {
+		return true;
+	} else if ((char0 >= CharCode.A && char0 <= CharCode.Z) || (char0 >= CharCode.a && char0 <= CharCode.z)) {
+		if (path.length > 2 && path.charCodeAt(1) === CharCode.Colon) {
+			const char2 = path.charCodeAt(2);
+			if (char2 === CharCode.Slash || char2 === CharCode.Backslash) {
+				return true;
+			}
+		}
+	}
+
+	return false;
+}
+
+export function isAbsolute_posix(path: string): boolean {
+	return !!(path && path.charCodeAt(0) === CharCode.Slash);
+}

--- a/src/vs/base/common/platform.ts
+++ b/src/vs/base/common/platform.ts
@@ -1,0 +1,162 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+let _isWindows = false;
+let _isMacintosh = false;
+let _isLinux = false;
+let _isNative = false;
+let _isWeb = false;
+let _locale: string | undefined = undefined;
+let _language: string | undefined = undefined;
+let _translationsConfigFile: string | undefined = undefined;
+
+interface NLSConfig {
+	locale: string;
+	availableLanguages: { [key: string]: string; };
+	_translationsConfigFile: string;
+}
+
+export interface IProcessEnvironment {
+	[key: string]: string;
+}
+
+interface INodeProcess {
+	platform: string;
+	env: IProcessEnvironment;
+	getuid(): number;
+	nextTick: Function;
+}
+declare let process: INodeProcess;
+declare let global: any;
+
+interface INavigator {
+	userAgent: string;
+	language: string;
+}
+declare let navigator: INavigator;
+declare let self: any;
+
+export const LANGUAGE_DEFAULT = 'en';
+
+// OS detection
+if (typeof process === 'object' && typeof process.nextTick === 'function' && typeof process.platform === 'string') {
+	_isWindows = (process.platform === 'win32');
+	_isMacintosh = (process.platform === 'darwin');
+	_isLinux = (process.platform === 'linux');
+	_locale = LANGUAGE_DEFAULT;
+	_language = LANGUAGE_DEFAULT;
+	const rawNlsConfig = process.env['VSCODE_NLS_CONFIG'];
+	if (rawNlsConfig) {
+		try {
+			const nlsConfig: NLSConfig = JSON.parse(rawNlsConfig);
+			const resolved = nlsConfig.availableLanguages['*'];
+			_locale = nlsConfig.locale;
+			// VSCode's default language is 'en'
+			_language = resolved ? resolved : LANGUAGE_DEFAULT;
+			_translationsConfigFile = nlsConfig._translationsConfigFile;
+		} catch (e) {
+		}
+	}
+	_isNative = true;
+} else if (typeof navigator === 'object') {
+	const userAgent = navigator.userAgent;
+	_isWindows = userAgent.indexOf('Windows') >= 0;
+	_isMacintosh = userAgent.indexOf('Macintosh') >= 0;
+	_isLinux = userAgent.indexOf('Linux') >= 0;
+	_isWeb = true;
+	_locale = navigator.language;
+	_language = _locale;
+}
+
+export const enum Platform {
+	Web,
+	Mac,
+	Linux,
+	Windows
+}
+export function PlatformToString(platform: Platform) {
+	switch (platform) {
+		case Platform.Web: return 'Web';
+		case Platform.Mac: return 'Mac';
+		case Platform.Linux: return 'Linux';
+		case Platform.Windows: return 'Windows';
+	}
+}
+
+let _platform: Platform = Platform.Web;
+if (_isNative) {
+	if (_isMacintosh) {
+		_platform = Platform.Mac;
+	} else if (_isWindows) {
+		_platform = Platform.Windows;
+	} else if (_isLinux) {
+		_platform = Platform.Linux;
+	}
+}
+
+export const isWindows = _isWindows;
+export const isMacintosh = _isMacintosh;
+export const isLinux = _isLinux;
+export const isNative = _isNative;
+export const isWeb = _isWeb;
+export const platform = _platform;
+
+export function isRootUser(): boolean {
+	return _isNative && !_isWindows && (process.getuid() === 0);
+}
+
+/**
+ * The language used for the user interface. The format of
+ * the string is all lower case (e.g. zh-tw for Traditional
+ * Chinese)
+ */
+export const language = _language;
+
+/**
+ * The OS locale or the locale specified by --locale. The format of
+ * the string is all lower case (e.g. zh-tw for Traditional
+ * Chinese). The UI is not necessarily shown in the provided locale.
+ */
+export const locale = _locale;
+
+/**
+ * The translatios that are available through language packs.
+ */
+export const translationsConfigFile = _translationsConfigFile;
+
+const _globals = (typeof self === 'object' ? self : typeof global === 'object' ? global : {} as any);
+export const globals: any = _globals;
+
+let _setImmediate: ((callback: (...args: any[]) => void) => number) | null = null;
+export function setImmediate(callback: (...args: any[]) => void): number {
+	if (_setImmediate === null) {
+		if (globals.setImmediate) {
+			_setImmediate = globals.setImmediate.bind(globals);
+		} else if (typeof process !== 'undefined' && typeof process.nextTick === 'function') {
+			_setImmediate = process.nextTick.bind(process);
+		} else {
+			_setImmediate = globals.setTimeout.bind(globals);
+		}
+	}
+	return _setImmediate!(callback);
+}
+
+export const enum OperatingSystem {
+	Windows = 1,
+	Macintosh = 2,
+	Linux = 3
+}
+export const OS = (_isMacintosh ? OperatingSystem.Macintosh : (_isWindows ? OperatingSystem.Windows : OperatingSystem.Linux));
+
+export const enum AccessibilitySupport {
+	/**
+	 * This should be the browser case where it is not known if a screen reader is attached or no.
+	 */
+	Unknown = 0,
+
+	Disabled = 1,
+
+	Enabled = 2
+}

--- a/src/vs/base/common/strings.ts
+++ b/src/vs/base/common/strings.ts
@@ -1,0 +1,701 @@
+/*---------------------------------------------------------------------------------------------
+ *  Copyright (c) Microsoft Corporation. All rights reserved.
+ *  Licensed under the MIT License. See License.txt in the project root for license information.
+ *--------------------------------------------------------------------------------------------*/
+
+import { CharCode } from './charCode';
+
+/**
+ * The empty string.
+ */
+export const empty = '';
+
+export function isFalsyOrWhitespace(str: string): boolean {
+	if (!str || typeof str !== 'string') {
+		return true;
+	}
+	return str.trim().length === 0;
+}
+
+/**
+ * @returns the provided number with the given number of preceding zeros.
+ */
+export function pad(n: number, l: number, char: string = '0'): string {
+	let str = '' + n;
+	let r = [str];
+
+	for (let i = str.length; i < l; i++) {
+		r.push(char);
+	}
+
+	return r.reverse().join('');
+}
+
+const _formatRegexp = /{(\d+)}/g;
+
+/**
+ * Helper to produce a string with a variable number of arguments. Insert variable segments
+ * into the string using the {n} notation where N is the index of the argument following the string.
+ * @param value string to which formatting is applied
+ * @param args replacements for {n}-entries
+ */
+export function format(value: string, ...args: any[]): string {
+	if (args.length === 0) {
+		return value;
+	}
+	return value.replace(_formatRegexp, function (match, group) {
+		let idx = parseInt(group, 10);
+		return isNaN(idx) || idx < 0 || idx >= args.length ?
+			match :
+			args[idx];
+	});
+}
+
+/**
+ * Converts HTML characters inside the string to use entities instead. Makes the string safe from
+ * being used e.g. in HTMLElement.innerHTML.
+ */
+export function escape(html: string): string {
+	return html.replace(/[<|>|&]/g, function (match) {
+		switch (match) {
+			case '<': return '&lt;';
+			case '>': return '&gt;';
+			case '&': return '&amp;';
+			default: return match;
+		}
+	});
+}
+
+/**
+ * Escapes regular expression characters in a given string
+ */
+export function escapeRegExpCharacters(value: string): string {
+	return value.replace(/[\-\\\{\}\*\+\?\|\^\$\.\[\]\(\)\#]/g, '\\$&');
+}
+
+/**
+ * Removes all occurrences of needle from the beginning and end of haystack.
+ * @param haystack string to trim
+ * @param needle the thing to trim (default is a blank)
+ */
+export function trim(haystack: string, needle: string = ' '): string | undefined {
+	let trimmed = ltrim(haystack, needle);
+	return rtrim(trimmed, needle);
+}
+
+/**
+ * Removes all occurrences of needle from the beginning of haystack.
+ * @param haystack string to trim
+ * @param needle the thing to trim
+ */
+export function ltrim(haystack: string, needle: string): string {
+	if (!haystack || !needle) {
+		return haystack;
+	}
+
+	let needleLen = needle.length;
+	if (needleLen === 0 || haystack.length === 0) {
+		return haystack;
+	}
+
+	let offset = 0;
+
+	while (haystack.indexOf(needle, offset) === offset) {
+		offset = offset + needleLen;
+	}
+	return haystack.substring(offset);
+}
+
+/**
+ * Removes all occurrences of needle from the end of haystack.
+ * @param haystack string to trim
+ * @param needle the thing to trim
+ */
+export function rtrim(haystack: string, needle: string): string {
+	if (!haystack || !needle) {
+		return haystack;
+	}
+
+	let needleLen = needle.length,
+		haystackLen = haystack.length;
+
+	if (needleLen === 0 || haystackLen === 0) {
+		return haystack;
+	}
+
+	let offset = haystackLen,
+		idx = -1;
+
+	while (true) {
+		idx = haystack.lastIndexOf(needle, offset - 1);
+		if (idx === -1 || idx + needleLen !== offset) {
+			break;
+		}
+		if (idx === 0) {
+			return '';
+		}
+		offset = idx;
+	}
+
+	return haystack.substring(0, offset);
+}
+
+export function convertSimple2RegExpPattern(pattern: string): string {
+	return pattern.replace(/[\-\\\{\}\+\?\|\^\$\.\,\[\]\(\)\#\s]/g, '\\$&').replace(/[\*]/g, '.*');
+}
+
+export function stripWildcards(pattern: string): string {
+	return pattern.replace(/\*/g, '');
+}
+
+/**
+ * Determines if haystack starts with needle.
+ */
+export function startsWith(haystack: string, needle: string): boolean {
+	if (haystack.length < needle.length) {
+		return false;
+	}
+
+	if (haystack === needle) {
+		return true;
+	}
+
+	for (let i = 0; i < needle.length; i++) {
+		if (haystack[i] !== needle[i]) {
+			return false;
+		}
+	}
+
+	return true;
+}
+
+/**
+ * Determines if haystack ends with needle.
+ */
+export function endsWith(haystack: string, needle: string): boolean {
+	let diff = haystack.length - needle.length;
+	if (diff > 0) {
+		return haystack.indexOf(needle, diff) === diff;
+	} else if (diff === 0) {
+		return haystack === needle;
+	} else {
+		return false;
+	}
+}
+
+export interface RegExpOptions {
+	matchCase?: boolean;
+	wholeWord?: boolean;
+	multiline?: boolean;
+	global?: boolean;
+}
+
+export function createRegExp(searchString: string, isRegex: boolean, options: RegExpOptions = {}): RegExp {
+	if (!searchString) {
+		throw new Error('Cannot create regex from empty string');
+	}
+	if (!isRegex) {
+		searchString = escapeRegExpCharacters(searchString);
+	}
+	if (options.wholeWord) {
+		if (!/\B/.test(searchString.charAt(0))) {
+			searchString = '\\b' + searchString;
+		}
+		if (!/\B/.test(searchString.charAt(searchString.length - 1))) {
+			searchString = searchString + '\\b';
+		}
+	}
+	let modifiers = '';
+	if (options.global) {
+		modifiers += 'g';
+	}
+	if (!options.matchCase) {
+		modifiers += 'i';
+	}
+	if (options.multiline) {
+		modifiers += 'm';
+	}
+
+	return new RegExp(searchString, modifiers);
+}
+
+export function regExpLeadsToEndlessLoop(regexp: RegExp): boolean {
+	// Exit early if it's one of these special cases which are meant to match
+	// against an empty string
+	if (regexp.source === '^' || regexp.source === '^$' || regexp.source === '$' || regexp.source === '^\\s*$') {
+		return false;
+	}
+
+	// We check against an empty string. If the regular expression doesn't advance
+	// (e.g. ends in an endless loop) it will match an empty string.
+	let match = regexp.exec('');
+	return !!(match && <any>regexp.lastIndex === 0);
+}
+
+export function regExpContainsBackreference(regexpValue: string): boolean {
+	return !!regexpValue.match(/([^\\]|^)(\\\\)*\\\d+/);
+}
+
+/**
+ * Returns first index of the string that is not whitespace.
+ * If string is empty or contains only whitespaces, returns -1
+ */
+export function firstNonWhitespaceIndex(str: string): number {
+	for (let i = 0, len = str.length; i < len; i++) {
+		let chCode = str.charCodeAt(i);
+		if (chCode !== CharCode.Space && chCode !== CharCode.Tab) {
+			return i;
+		}
+	}
+	return -1;
+}
+
+/**
+ * Returns the leading whitespace of the string.
+ * If the string contains only whitespaces, returns entire string
+ */
+export function getLeadingWhitespace(str: string, start: number = 0, end: number = str.length): string {
+	for (let i = start; i < end; i++) {
+		let chCode = str.charCodeAt(i);
+		if (chCode !== CharCode.Space && chCode !== CharCode.Tab) {
+			return str.substring(start, i);
+		}
+	}
+	return str.substring(start, end);
+}
+
+/**
+ * Returns last index of the string that is not whitespace.
+ * If string is empty or contains only whitespaces, returns -1
+ */
+export function lastNonWhitespaceIndex(str: string, startIndex: number = str.length - 1): number {
+	for (let i = startIndex; i >= 0; i--) {
+		let chCode = str.charCodeAt(i);
+		if (chCode !== CharCode.Space && chCode !== CharCode.Tab) {
+			return i;
+		}
+	}
+	return -1;
+}
+
+export function compare(a: string, b: string): number {
+	if (a < b) {
+		return -1;
+	} else if (a > b) {
+		return 1;
+	} else {
+		return 0;
+	}
+}
+
+export function compareIgnoreCase(a: string, b: string): number {
+	const len = Math.min(a.length, b.length);
+	for (let i = 0; i < len; i++) {
+		let codeA = a.charCodeAt(i);
+		let codeB = b.charCodeAt(i);
+
+		if (codeA === codeB) {
+			// equal
+			continue;
+		}
+
+		if (isUpperAsciiLetter(codeA)) {
+			codeA += 32;
+		}
+
+		if (isUpperAsciiLetter(codeB)) {
+			codeB += 32;
+		}
+
+		const diff = codeA - codeB;
+
+		if (diff === 0) {
+			// equal -> ignoreCase
+			continue;
+
+		} else if (isLowerAsciiLetter(codeA) && isLowerAsciiLetter(codeB)) {
+			//
+			return diff;
+
+		} else {
+			return compare(a.toLowerCase(), b.toLowerCase());
+		}
+	}
+
+	if (a.length < b.length) {
+		return -1;
+	} else if (a.length > b.length) {
+		return 1;
+	} else {
+		return 0;
+	}
+}
+
+export function isLowerAsciiLetter(code: number): boolean {
+	return code >= CharCode.a && code <= CharCode.z;
+}
+
+export function isUpperAsciiLetter(code: number): boolean {
+	return code >= CharCode.A && code <= CharCode.Z;
+}
+
+function isAsciiLetter(code: number): boolean {
+	return isLowerAsciiLetter(code) || isUpperAsciiLetter(code);
+}
+
+export function equalsIgnoreCase(a: string, b: string): boolean {
+	const len1 = a ? a.length : 0;
+	const len2 = b ? b.length : 0;
+
+	if (len1 !== len2) {
+		return false;
+	}
+
+	return doEqualsIgnoreCase(a, b);
+}
+
+function doEqualsIgnoreCase(a: string, b: string, stopAt = a.length): boolean {
+	if (typeof a !== 'string' || typeof b !== 'string') {
+		return false;
+	}
+
+	for (let i = 0; i < stopAt; i++) {
+		const codeA = a.charCodeAt(i);
+		const codeB = b.charCodeAt(i);
+
+		if (codeA === codeB) {
+			continue;
+		}
+
+		// a-z A-Z
+		if (isAsciiLetter(codeA) && isAsciiLetter(codeB)) {
+			let diff = Math.abs(codeA - codeB);
+			if (diff !== 0 && diff !== 32) {
+				return false;
+			}
+		}
+
+		// Any other charcode
+		else {
+			if (String.fromCharCode(codeA).toLowerCase() !== String.fromCharCode(codeB).toLowerCase()) {
+				return false;
+			}
+		}
+	}
+
+	return true;
+}
+
+export function startsWithIgnoreCase(str: string, candidate: string): boolean {
+	const candidateLength = candidate.length;
+	if (candidate.length > str.length) {
+		return false;
+	}
+
+	return doEqualsIgnoreCase(str, candidate, candidateLength);
+}
+
+/**
+ * @returns the length of the common prefix of the two strings.
+ */
+export function commonPrefixLength(a: string, b: string): number {
+
+	let i: number,
+		len = Math.min(a.length, b.length);
+
+	for (i = 0; i < len; i++) {
+		if (a.charCodeAt(i) !== b.charCodeAt(i)) {
+			return i;
+		}
+	}
+
+	return len;
+}
+
+/**
+ * @returns the length of the common suffix of the two strings.
+ */
+export function commonSuffixLength(a: string, b: string): number {
+
+	let i: number,
+		len = Math.min(a.length, b.length);
+
+	let aLastIndex = a.length - 1;
+	let bLastIndex = b.length - 1;
+
+	for (i = 0; i < len; i++) {
+		if (a.charCodeAt(aLastIndex - i) !== b.charCodeAt(bLastIndex - i)) {
+			return i;
+		}
+	}
+
+	return len;
+}
+
+function substrEquals(a: string, aStart: number, aEnd: number, b: string, bStart: number, bEnd: number): boolean {
+	while (aStart < aEnd && bStart < bEnd) {
+		if (a[aStart] !== b[bStart]) {
+			return false;
+		}
+		aStart += 1;
+		bStart += 1;
+	}
+	return true;
+}
+
+/**
+ * Return the overlap between the suffix of `a` and the prefix of `b`.
+ * For instance `overlap("foobar", "arr, I'm a pirate") === 2`.
+ */
+export function overlap(a: string, b: string): number {
+	let aEnd = a.length;
+	let bEnd = b.length;
+	let aStart = aEnd - bEnd;
+
+	if (aStart === 0) {
+		return a === b ? aEnd : 0;
+	} else if (aStart < 0) {
+		bEnd += aStart;
+		aStart = 0;
+	}
+
+	while (aStart < aEnd && bEnd > 0) {
+		if (substrEquals(a, aStart, aEnd, b, 0, bEnd)) {
+			return bEnd;
+		}
+		bEnd -= 1;
+		aStart += 1;
+	}
+	return 0;
+}
+
+// --- unicode
+// http://en.wikipedia.org/wiki/Surrogate_pair
+// Returns the code point starting at a specified index in a string
+// Code points U+0000 to U+D7FF and U+E000 to U+FFFF are represented on a single character
+// Code points U+10000 to U+10FFFF are represented on two consecutive characters
+//export function getUnicodePoint(str:string, index:number, len:number):number {
+//	let chrCode = str.charCodeAt(index);
+//	if (0xD800 <= chrCode && chrCode <= 0xDBFF && index + 1 < len) {
+//		let nextChrCode = str.charCodeAt(index + 1);
+//		if (0xDC00 <= nextChrCode && nextChrCode <= 0xDFFF) {
+//			return (chrCode - 0xD800) << 10 + (nextChrCode - 0xDC00) + 0x10000;
+//		}
+//	}
+//	return chrCode;
+//}
+export function isHighSurrogate(charCode: number): boolean {
+	return (0xD800 <= charCode && charCode <= 0xDBFF);
+}
+
+export function isLowSurrogate(charCode: number): boolean {
+	return (0xDC00 <= charCode && charCode <= 0xDFFF);
+}
+
+/**
+ * Generated using https://github.com/alexandrudima/unicode-utils/blob/master/generate-rtl-test.js
+ */
+const CONTAINS_RTL = /(?:[\u05BE\u05C0\u05C3\u05C6\u05D0-\u05F4\u0608\u060B\u060D\u061B-\u064A\u066D-\u066F\u0671-\u06D5\u06E5\u06E6\u06EE\u06EF\u06FA-\u0710\u0712-\u072F\u074D-\u07A5\u07B1-\u07EA\u07F4\u07F5\u07FA-\u0815\u081A\u0824\u0828\u0830-\u0858\u085E-\u08BD\u200F\uFB1D\uFB1F-\uFB28\uFB2A-\uFD3D\uFD50-\uFDFC\uFE70-\uFEFC]|\uD802[\uDC00-\uDD1B\uDD20-\uDE00\uDE10-\uDE33\uDE40-\uDEE4\uDEEB-\uDF35\uDF40-\uDFFF]|\uD803[\uDC00-\uDCFF]|\uD83A[\uDC00-\uDCCF\uDD00-\uDD43\uDD50-\uDFFF]|\uD83B[\uDC00-\uDEBB])/;
+
+/**
+ * Returns true if `str` contains any Unicode character that is classified as "R" or "AL".
+ */
+export function containsRTL(str: string): boolean {
+	return CONTAINS_RTL.test(str);
+}
+
+/**
+ * Generated using https://github.com/alexandrudima/unicode-utils/blob/master/generate-emoji-test.js
+ */
+const CONTAINS_EMOJI = /(?:[\u231A\u231B\u23F0\u23F3\u2600-\u27BF\u2B50\u2B55]|\uD83C[\uDDE6-\uDDFF\uDF00-\uDFFF]|\uD83D[\uDC00-\uDE4F\uDE80-\uDEF8]|\uD83E[\uDD00-\uDDE6])/;
+
+export function containsEmoji(str: string): boolean {
+	return CONTAINS_EMOJI.test(str);
+}
+
+const IS_BASIC_ASCII = /^[\t\n\r\x20-\x7E]*$/;
+/**
+ * Returns true if `str` contains only basic ASCII characters in the range 32 - 126 (including 32 and 126) or \n, \r, \t
+ */
+export function isBasicASCII(str: string): boolean {
+	return IS_BASIC_ASCII.test(str);
+}
+
+export function containsFullWidthCharacter(str: string): boolean {
+	for (let i = 0, len = str.length; i < len; i++) {
+		if (isFullWidthCharacter(str.charCodeAt(i))) {
+			return true;
+		}
+	}
+	return false;
+}
+
+export function isFullWidthCharacter(charCode: number): boolean {
+	// Do a cheap trick to better support wrapping of wide characters, treat them as 2 columns
+	// http://jrgraphix.net/research/unicode_blocks.php
+	//          2E80 — 2EFF   CJK Radicals Supplement
+	//          2F00 — 2FDF   Kangxi Radicals
+	//          2FF0 — 2FFF   Ideographic Description Characters
+	//          3000 — 303F   CJK Symbols and Punctuation
+	//          3040 — 309F   Hiragana
+	//          30A0 — 30FF   Katakana
+	//          3100 — 312F   Bopomofo
+	//          3130 — 318F   Hangul Compatibility Jamo
+	//          3190 — 319F   Kanbun
+	//          31A0 — 31BF   Bopomofo Extended
+	//          31F0 — 31FF   Katakana Phonetic Extensions
+	//          3200 — 32FF   Enclosed CJK Letters and Months
+	//          3300 — 33FF   CJK Compatibility
+	//          3400 — 4DBF   CJK Unified Ideographs Extension A
+	//          4DC0 — 4DFF   Yijing Hexagram Symbols
+	//          4E00 — 9FFF   CJK Unified Ideographs
+	//          A000 — A48F   Yi Syllables
+	//          A490 — A4CF   Yi Radicals
+	//          AC00 — D7AF   Hangul Syllables
+	// [IGNORE] D800 — DB7F   High Surrogates
+	// [IGNORE] DB80 — DBFF   High Private Use Surrogates
+	// [IGNORE] DC00 — DFFF   Low Surrogates
+	// [IGNORE] E000 — F8FF   Private Use Area
+	//          F900 — FAFF   CJK Compatibility Ideographs
+	// [IGNORE] FB00 — FB4F   Alphabetic Presentation Forms
+	// [IGNORE] FB50 — FDFF   Arabic Presentation Forms-A
+	// [IGNORE] FE00 — FE0F   Variation Selectors
+	// [IGNORE] FE20 — FE2F   Combining Half Marks
+	// [IGNORE] FE30 — FE4F   CJK Compatibility Forms
+	// [IGNORE] FE50 — FE6F   Small Form Variants
+	// [IGNORE] FE70 — FEFF   Arabic Presentation Forms-B
+	//          FF00 — FFEF   Halfwidth and Fullwidth Forms
+	//               [https://en.wikipedia.org/wiki/Halfwidth_and_fullwidth_forms]
+	//               of which FF01 - FF5E fullwidth ASCII of 21 to 7E
+	// [IGNORE]    and FF65 - FFDC halfwidth of Katakana and Hangul
+	// [IGNORE] FFF0 — FFFF   Specials
+	charCode = +charCode; // @perf
+	return (
+		(charCode >= 0x2E80 && charCode <= 0xD7AF)
+		|| (charCode >= 0xF900 && charCode <= 0xFAFF)
+		|| (charCode >= 0xFF01 && charCode <= 0xFF5E)
+	);
+}
+
+/**
+ * Given a string and a max length returns a shorted version. Shorting
+ * happens at favorable positions - such as whitespace or punctuation characters.
+ */
+export function lcut(text: string, n: number) {
+	if (text.length < n) {
+		return text;
+	}
+
+	const re = /\b/g;
+	let i = 0;
+	while (re.test(text)) {
+		if (text.length - re.lastIndex < n) {
+			break;
+		}
+
+		i = re.lastIndex;
+		re.lastIndex += 1;
+	}
+
+	return text.substring(i).replace(/^\s/, empty);
+}
+
+// Escape codes
+// http://en.wikipedia.org/wiki/ANSI_escape_code
+const EL = /\x1B\x5B[12]?K/g; // Erase in line
+const COLOR_START = /\x1b\[\d+m/g; // Color
+const COLOR_END = /\x1b\[0?m/g; // Color
+
+export function removeAnsiEscapeCodes(str: string): string {
+	if (str) {
+		str = str.replace(EL, '');
+		str = str.replace(COLOR_START, '');
+		str = str.replace(COLOR_END, '');
+	}
+
+	return str;
+}
+
+// -- UTF-8 BOM
+
+export const UTF8_BOM_CHARACTER = String.fromCharCode(CharCode.UTF8_BOM);
+
+export function startsWithUTF8BOM(str: string): boolean {
+	return !!(str && str.length > 0 && str.charCodeAt(0) === CharCode.UTF8_BOM);
+}
+
+export function stripUTF8BOM(str: string): string {
+	return startsWithUTF8BOM(str) ? str.substr(1) : str;
+}
+
+export function repeat(s: string, count: number): string {
+	let result = '';
+	for (let i = 0; i < count; i++) {
+		result += s;
+	}
+	return result;
+}
+
+/**
+ * Checks if the characters of the provided query string are included in the
+ * target string. The characters do not have to be contiguous within the string.
+ */
+export function fuzzyContains(target: string, query: string): boolean {
+	if (!target || !query) {
+		return false; // return early if target or query are undefined
+	}
+
+	if (target.length < query.length) {
+		return false; // impossible for query to be contained in target
+	}
+
+	const queryLen = query.length;
+	const targetLower = target.toLowerCase();
+
+	let index = 0;
+	let lastIndexOf = -1;
+	while (index < queryLen) {
+		let indexOf = targetLower.indexOf(query[index], lastIndexOf + 1);
+		if (indexOf < 0) {
+			return false;
+		}
+
+		lastIndexOf = indexOf;
+
+		index++;
+	}
+
+	return true;
+}
+
+export function containsUppercaseCharacter(target: string, ignoreEscapedChars = false): boolean {
+	if (!target) {
+		return false;
+	}
+
+	if (ignoreEscapedChars) {
+		target = target.replace(/\\./g, '');
+	}
+
+	return target.toLowerCase() !== target;
+}
+
+export function uppercaseFirstLetter(str: string): string {
+	return str.charAt(0).toUpperCase() + str.slice(1);
+}
+
+export function getNLines(str: string, n = 1): string {
+	if (n === 0) {
+		return '';
+	}
+
+	let idx = -1;
+	do {
+		idx = str.indexOf('\n', idx + 1);
+		n--;
+	} while (n > 0 && idx >= 0);
+
+	return idx >= 0 ?
+		str.substr(0, idx) :
+		str;
+}


### PR DESCRIPTION
VS Code handles a large list of symbols very poorly.

In our code base we have about 15k ctag symbols. It takes about 3 seconds to show the symbol list and is very sluggish as you type, rendering the symbol lookup feature useless to us.

This request changes two things:
1. If there are less than 2 characters in the query does not return anything.
2. Compare the symbol name to the query and only add it to the result set if it is a partial match.

This improves the symbol lookup dramatically for us.